### PR TITLE
refactor: rename /create-project to /initialize-backlog and move metadata file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,14 +11,14 @@ There is **no source code, no build, no tests, no lint**. Each command file is a
 ## The commands and their workflow
 
 ```
-create-project   ─►  plan-release   ─►  add-backlog-item / migrate-backlog
-                                              │
-                                              ├─►  refine-backlog ─► refine-backlog-item   (needs-clarification)
-                                              ├─►  validate-backlog                        (read-only audit)
-                                              └─►  execute-backlog-item                    (picks topmost unblocked)
+initialize-backlog   ─►  plan-release   ─►  add-backlog-item / migrate-backlog
+                                                  │
+                                                  ├─►  refine-backlog ─► refine-backlog-item   (needs-clarification)
+                                                  ├─►  validate-backlog                        (read-only audit)
+                                                  └─►  execute-backlog-item                    (picks topmost unblocked)
 ```
 
-`create-project` is the bootstrap. Every other command preflights for a Project linked to the repo and stops with the standard error if missing. `plan-release` creates Milestones (releases). `add-backlog-item` and `migrate-backlog` create Issues. `execute-backlog-item` picks work. `refine-backlog` orchestrates a session over items flagged `needs-clarification`, delegating each to `refine-backlog-item`. `validate-backlog` audits without mutating.
+`initialize-backlog` is the bootstrap. Every other command preflights for a Project linked to the repo and stops with the standard error if missing. `plan-release` creates Milestones (releases). `add-backlog-item` and `migrate-backlog` create Issues. `execute-backlog-item` picks work. `refine-backlog` orchestrates a session over items flagged `needs-clarification`, delegating each to `refine-backlog-item`. `validate-backlog` audits without mutating.
 
 ## Invariants that MUST be preserved across all commands
 
@@ -29,16 +29,16 @@ grep -hoE "type:[a-z-]+" commands/*.md | sort -u           # 9 type labels
 grep -hoE "priority:P[0-3]" commands/*.md | sort -u         # 4 priority labels
 grep -hoE "effort:(XS|S|M|L|XL)\b" commands/*.md | sort -u  # 5 effort labels
 grep -n "No Backlog project linked" commands/*.md           # identical preflight stop string in 7 files
-grep -n ".git/info/backlog-project.json" commands/*.md      # cache file referenced everywhere
+grep -n ".claude/backlog-project.json" commands/*.md        # metadata file referenced everywhere
 ```
 
 1. **Label catalog** — `type:{feature,bug,security,performance,dx,tech-debt,reliability,compliance,spike}`, `priority:{P0,P1,P2,P3}`, `effort:{XS,S,M,L,XL}`, plus `needs-clarification`. Any new value or rename must be applied in all command files.
 
-2. **Standard preflight stop string** — every consumer command outputs *exactly* `No Backlog project linked to <owner>/<repo>. Run /create-project first.` when no Project is found.
+2. **Standard preflight stop string** — every consumer command outputs *exactly* `No Backlog project linked to <owner>/<repo>. Run /initialize-backlog first.` when the metadata file is missing.
 
-3. **Issue Forms template body shape** — section headings `### What`, `### Why`, `### In Scope`, `### Out of Scope`, `### Acceptance Criteria`, `### INVEST Notes` (in this order). `validate-backlog` parses these by exact match. `add-backlog-item`, `migrate-backlog`, `refine-backlog-item` all emit bodies that conform. The template itself is authored at runtime by `create-project` (NOT committed in this repo) and goes out via PR, never direct commit.
+3. **Issue Forms template body shape** — section headings `### What`, `### Why`, `### In Scope`, `### Out of Scope`, `### Acceptance Criteria`, `### INVEST Notes` (in this order). `validate-backlog` parses these by exact match. `add-backlog-item`, `migrate-backlog`, `refine-backlog-item` all emit bodies that conform. The template itself is authored at runtime by `initialize-backlog` (NOT committed in this repo) and goes out via PR, never direct commit.
 
-4. **Cache file location** — `.git/info/backlog-project.json` (inside `.git/`, never tracked). 24-hour TTL. `create-project` writes it; the other 5 consumers read it with live-query fallback. Schema documented in `create-project.md`.
+4. **Metadata file location** — `.claude/backlog-project.json`. `initialize-backlog` writes it; all other commands read it directly with no live-query fallback. Schema documented in `initialize-backlog.md`.
 
 5. **Active milestone resolution** — earliest open `due_on`, tie-break by lowest version parsed from milestone title (`v1.2.0` < `v1.3.0`), fallback to milestone `number` for non-parseable titles. When no milestone has `due_on`, lowest version wins. This logic must match in `execute-backlog-item` and `add-backlog-item`.
 
@@ -55,14 +55,14 @@ These were made deliberately — don't undo without explicit user direction:
 - **Single repo, single Project** — `Backlog` titled Project v2 linked to the active repo. No cross-repo Projects.
 - **Status is the only Project v2 custom field** — bucket/priority/effort live as repo labels (visible on issue cards everywhere).
 - **`migrate-backlog` skips Done items** — historical work is not migrated to GitHub. PR shipped references stay in the source `BACKLOG.md`.
-- **Issue Forms template ships via PR** — `create-project` opens a `chore/backlog-item-issue-template` PR; it never commits the template directly to the default branch.
+- **Issue Forms template ships via PR** — `initialize-backlog` opens a `chore/backlog-item-issue-template` PR; it never commits the template directly to the default branch.
 - **`validate-backlog` is strictly read-only** — never mutates issues. It surfaces `gh issue edit ...` snippets the user can run.
 - **Migration dep inference is opt-in** — `migrate-backlog` scans source prose for hints like "depends on" / "blocked by" but presents all candidates in a single review block and applies only after user confirmation.
 
 ## When editing commands
 
 - Match the existing style: numbered workflow sections with `(MANDATORY)` / `(STRICT)` / `(RELATIVE)` flags, opening prose `You are an AI agent acting as...`, `Rules & Constraints` section, `Output Expectations` section.
-- New commands MUST add the standard preflight block (auth → origin parse → cache read → live-query fallback → standard stop string → label catalog check).
+- New commands MUST add the standard preflight block (auth → origin parse → metadata file read → standard stop string → label catalog check).
 - After non-trivial edits, run the consistency greps above and verify no spurious bucket/Bucket leftovers (`grep -nE "[Bb]ucket" commands/*.md` should be empty — that term was renamed to `type` in this repo's history).
 - All `gh` errors must be surfaced verbatim — never swallow.
 
@@ -70,7 +70,7 @@ These were made deliberately — don't undo without explicit user direction:
 
 There is no automated test suite. The end-to-end smoke is:
 
-1. `/create-project` in a fresh repo with `gh auth status` succeeding → verify Project, labels, Issue Forms PR.
+1. `/initialize-backlog` in a fresh repo with `gh auth status` succeeding → verify Project, labels, Issue Forms PR, `.claude/backlog-project.json` written.
 2. `/plan-release` → milestone created with `due_on`.
 3. `/add-backlog-item` → issue with all three label groups, body matches template, item in Project at the chosen rank with Status=Todo, deps applied if declared.
 4. `/migrate-backlog` against a small sample BACKLOG.md including a Done item → Done item skipped, others migrated, dep inference candidates reviewed.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Restart Claude Code if it was already running. All commands below are then avail
 
 | Command | What it does |
 |---|---|
-| `/create-project` | One-time bootstrap: provisions the GitHub Project v2, the full label catalog, and the Issue Forms template. Idempotent — safe to re-run. |
+| `/initialize-backlog` | One-time bootstrap: provisions the GitHub Project v2, the full label catalog, and the Issue Forms template. Idempotent — safe to re-run. |
 | `/plan-release` | Creates a Milestone with a due date. Tie-breaks and active-milestone resolution are automatic. |
 | `/add-backlog-item` | Interactively authors a single backlog item. Enforces INVEST, recommends rank and priority, wires up native GitHub dependencies. |
 | `/migrate-backlog` | Bulk-imports an existing `BACKLOG.md`. Skips Done items. Dependency inference is opt-in — candidates are reviewed before anything is applied. |
@@ -107,15 +107,15 @@ Priority is severity classification. Execution order is the manual Project rank 
 ### Workflow
 
 ```
-/create-project ──► /plan-release ──► /add-backlog-item
-                                      /migrate-backlog
-                                            │
-                                            ├──► /refine-backlog ──► /refine-backlog-item
-                                            ├──► /validate-backlog  (read-only)
-                                            └──► /execute-backlog-item
+/initialize-backlog ──► /plan-release ──► /add-backlog-item
+                                          /migrate-backlog
+                                                │
+                                                ├──► /refine-backlog ──► /refine-backlog-item
+                                                ├──► /validate-backlog  (read-only)
+                                                └──► /execute-backlog-item
 ```
 
-Run `/create-project` once. Every other command preflights for the linked Project and stops with a clear error if it is missing.
+Run `/initialize-backlog` once. Every other command preflights for the linked Project and stops with a clear error if it is missing.
 
 ---
 
@@ -124,10 +124,10 @@ Run `/create-project` once. Every other command preflights for the linked Projec
 ### Starting from scratch
 
 ```
-/create-project
+/initialize-backlog
 ```
 
-This provisions the GitHub Project v2, creates all labels, and opens a PR with the Issue Forms template. Run it once per repo.
+This provisions the GitHub Project v2, creates all labels, opens a PR with the Issue Forms template, and writes `.claude/backlog-project.json`. Run it once per repo.
 
 ### Planning a release
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -13,7 +13,7 @@ A set of slash commands for a fully GitHub-native backlog workflow — Issues, P
 
 | Command | When to use |
 |---------|-------------|
-| `/create-project` | First-time setup: provisions Project, labels, Issue Forms template. Idempotent. Run this first. |
+| `/initialize-backlog` | First-time setup: provisions Project, labels, Issue Forms template. Idempotent. Run this first. |
 | `/plan-release` | Create a Milestone with a due date — choose Maintenance, Regular, or Automated mode; semver version inferred from scope |
 | `/add-backlog-item` | Interactively create and rank a single backlog item (enforces INVEST) |
 | `/migrate-backlog` | Bulk-import an existing backlog file; skips Done items; dep inference opt-in |
@@ -25,14 +25,14 @@ A set of slash commands for a fully GitHub-native backlog workflow — Issues, P
 ## Workflow
 
 ```
-create-project ─► plan-release ─► add-backlog-item / migrate-backlog
-                                          │
-                                          ├─► refine-backlog ─► refine-backlog-item
-                                          ├─► validate-backlog (read-only)
-                                          └─► execute-backlog-item
+initialize-backlog ─► plan-release ─► add-backlog-item / migrate-backlog
+                                              │
+                                              ├─► refine-backlog ─► refine-backlog-item
+                                              ├─► validate-backlog (read-only)
+                                              └─► execute-backlog-item
 ```
 
-`create-project` is the bootstrap. Every other command preflights for a linked Project and stops with a standard error if missing.
+`initialize-backlog` is the bootstrap. Every other command preflights for a linked Project and stops with a standard error if missing.
 
 ## Key Invariants (apply to all commands)
 
@@ -45,7 +45,7 @@ create-project ─► plan-release ─► add-backlog-item / migrate-backlog
 **Issue body sections** (exact headings, this order):
 `### What` · `### Why` · `### In Scope` · `### Out of Scope` · `### Acceptance Criteria` · `### INVEST Notes`
 
-**Cache**: `.git/info/backlog-project.json` — 24-hour TTL, lives inside `.git/`, never tracked.
+**Metadata file**: `.claude/backlog-project.json` — written by `initialize-backlog`, read directly by all other commands.
 
 **Priority vs rank**: `priority:*` is severity classification. Project rank (topmost Todo item) is execution order. They should stay consistent but are independent concepts — `execute-backlog-item` sorts by rank only.
 

--- a/commands/add-backlog-item.md
+++ b/commands/add-backlog-item.md
@@ -14,18 +14,11 @@ Your goal is to define, refine, prioritize, and add high-quality backlog items t
 
 Before any item work, verify the repository is provisioned:
 
-- Run `gh auth status`. If not authenticated, STOP and instruct the user to run `gh auth login`.
-- Run `git remote get-url origin`. Parse `<owner>/<repo>`. STOP if missing.
-- Resolve project metadata, preferring the local cache:
-  - Read `.git/info/backlog-project.json` if it exists.
-  - Use the cache when: the file exists, `owner`/`repo` match, and `cached_at` is within 24 hours.
-  - On cache miss/expiry: query `gh project list --owner <owner> --format json` filtered by repo link; on success, refresh the cache (write to a temp file under `.git/info/`, then rename atomically).
-  - If neither cache nor live query find a Project:
-    - STOP
-    - Output exactly: `No Backlog project linked to <owner>/<repo>. Run /create-project first.`
+- Read `.claude/backlog-project.json`. If the file does not exist, STOP and output exactly:
+  `No Backlog project linked to <owner>/<repo>. Run /initialize-backlog first.`
 - Verify the canonical label catalog is present (`type:*`, `priority:*`, `effort:*`):
   - `gh label list --limit 100`
-  - If any required label is missing, STOP and instruct the user to run `/create-project` to provision them
+  - If any required label is missing, STOP and instruct the user to run `/initialize-backlog` to provision them
 
 ---
 

--- a/commands/execute-backlog-item.md
+++ b/commands/execute-backlog-item.md
@@ -16,15 +16,8 @@ Select and execute the highest-priority actionable backlog item, scoped to the a
 
 ### 0. Preflight (MANDATORY)
 
-- Run `gh auth status`. If not authenticated, STOP and instruct the user to run `gh auth login`.
-- Run `git remote get-url origin`. Parse `<owner>/<repo>`. STOP if missing.
-- Resolve project metadata, preferring the local cache:
-  - Read `.git/info/backlog-project.json` if it exists.
-  - Use the cache when: the file exists, `owner`/`repo` match, and `cached_at` is within 24 hours. Cached `status_field_id` and `status_options` IDs save round-trips in step 5 and step 10.
-  - On cache miss/expiry: query `gh project list --owner <owner> --format json` filtered by repo link; on success, refresh the cache (write to a temp file under `.git/info/`, then rename atomically).
-  - If neither cache nor live query find a Project:
-    - STOP
-    - Output exactly: `No Backlog project linked to <owner>/<repo>. Run /create-project first.`
+- Read `.claude/backlog-project.json`. If the file does not exist, STOP and output exactly:
+  `No Backlog project linked to <owner>/<repo>. Run /initialize-backlog first.`
 
 ---
 

--- a/commands/initialize-backlog.md
+++ b/commands/initialize-backlog.md
@@ -1,4 +1,4 @@
-# create-project
+# initialize-backlog
 
 You are an AI agent acting as a Senior Project Manager responsible for bootstrapping the GitHub-native backlog system for this repository.
 
@@ -12,7 +12,7 @@ This command is **idempotent**: re-running it on a repo where the project alread
 
 Make the repository ready to host backlog items as GitHub Issues, prioritized inside a linked GitHub Project (v2), so that:
 
-- `add-backlog-item`, `migrate-backlog`, `execute-backlog-item`, and `validate-backlog` can all detect the project dynamically via `gh`
+- All other commands can all read project metadata from `.claude/backlog-project.json`
 - Issues created by any command share the same body shape (driven by the Issue Forms template)
 - Labels are uniform across `type:*`, `priority:*`, and `effort:*`
 
@@ -24,12 +24,10 @@ Make the repository ready to host backlog items as GitHub Issues, prioritized in
 
 Verify the local environment can talk to GitHub:
 
-- Run `gh auth status` — if not authenticated, STOP and instruct the user to run `gh auth login`
 - Parse `<owner>/<repo>` from the origin URL (support both `git@github.com:owner/repo.git` and `https://github.com/owner/repo.git` forms)
 - Confirm Issues are enabled: `gh repo view <owner>/<repo> --json hasIssuesEnabled --jq '.hasIssuesEnabled'`. If `false`, STOP and instruct the user to enable Issues in repository settings.
+- Confirm Projects are enabled: `gh repo view <owner>/<repo> --json hasProjectsEnabled --jq '.hasProjectsEnabled'`. If `false`, STOP and instruct the user to enable Projects in repository settings.
 - Confirm the GitHub Issue Dependencies API is reachable on this repo (used by `add-backlog-item`, `execute-backlog-item`, `validate-backlog`, `refine-backlog-item`, `migrate-backlog`):
-  - `gh api "repos/<owner>/<repo>/issues/dependencies" --silent` (returns `200` for enabled repos, `404` if the feature is unavailable on this plan).
-  - The Dependencies API and the Sub-issues API are GA. They are free for public repos and require a paid plan for private repos. If the response is `404` on a private repo, surface this as a warning (provisioning continues, but `execute-backlog-item`'s block-skipping and dependency audit checks will be no-ops on this repo).
 
 If any required preflight step fails:
 
@@ -45,7 +43,7 @@ Before creating anything:
 
 - Query existing projects:
   - `gh project list --owner <owner> --format json`
-- Filter for a Project (v2) titled `<repo> Backlog` (where `<repo>` is the repository name) that is linked to this repo
+- Filter for a Project (v2) titled `<owner>/<repo> Backlog` that is linked to this repo
 - If a matching Project exists:
   - Record its number and URL
   - SKIP step 3
@@ -58,10 +56,9 @@ Before creating anything:
 If no matching Project exists:
 
 - Create a new Project (v2):
-  - `gh project create --owner <owner> --title "<repo> Backlog"` (where `<repo>` is the repository name)
-- Link it to the repository and set it as the default repository:
+  - `gh project create --owner <owner> --title "<owner>/<repo> Backlog"`
+- Link it to the repository
   - `gh project link <project-number> --owner <owner> --repo <repo>`
-  - `gh repo set-default <owner>/<repo>` — ensures `gh` commands in this repo directory resolve to the correct remote
 - Set a canonical short description on the project:
   - Use the GraphQL mutation `updateProjectV2` with `shortDescription: "Backlog for <owner>/<repo>"`:
 
@@ -220,16 +217,18 @@ The rendered issue body produced by GitHub for this template uses `### What`, `#
 
 ---
 
-### 6. Cache Project Metadata (LOCAL, NEVER TRACKED)
+### 6. Persist Project Metadata
 
-To save other commands a round-trip on every invocation, persist project metadata to `.git/info/backlog-project.json`.
+Persist project metadata to `.claude/backlog-project.json` so other commands can read it without any live GitHub queries.
 
 Resolve the metadata via:
 
 - `gh project field-list <project-number> --owner <owner> --format json` — for the Status field's node ID and the option IDs for `Todo` / `In Progress` / `Done`
 - `gh project view <project-number> --owner <owner> --format json` — for the project's node ID
 
-Write atomically (temp file + rename) to avoid torn reads:
+Create the `.claude/` directory if needed: `mkdir -p .claude`
+
+Write the file:
 
 ```json
 {
@@ -243,16 +242,14 @@ Write atomically (temp file + rename) to avoid torn reads:
     "Todo": "<option-id>",
     "In Progress": "<option-id>",
     "Done": "<option-id>"
-  },
-  "cached_at": "<ISO 8601 timestamp>"
+  }
 }
 ```
 
 Schema notes:
 
-- `cached_at` lets readers expire the cache (recommended TTL: 24h)
-- All other commands MUST treat the cache as advisory — if any read fails, they fall back to live `gh` queries and refresh the cache themselves
-- Re-running `create-project` on a fully-provisioned repo MUST refresh the cache
+- This file is the single source of truth for project metadata — all other commands read it directly with no fallback
+- Re-running `initialize-backlog` on a fully-provisioned repo MUST refresh this file
 
 ---
 
@@ -266,7 +263,7 @@ Print a structured summary so the user can verify provisioning:
 - Labels created or updated (count, with full list)
 - Issue Forms template PR URL (or "already present, no PR needed")
 - Status field options confirmed
-- Cache file path: `.git/info/backlog-project.json`
+- Metadata file path: `.claude/backlog-project.json`
 
 ---
 

--- a/commands/migrate-backlog.md
+++ b/commands/migrate-backlog.md
@@ -24,18 +24,11 @@ Transform ALL existing backlog items into GitHub Issues while:
 
 ### 0. Preflight (MANDATORY)
 
-- Run `gh auth status`. If not authenticated, STOP and instruct the user to run `gh auth login`.
-- Run `git remote get-url origin`. Parse `<owner>/<repo>`. STOP if missing.
-- Resolve project metadata, preferring the local cache:
-  - Read `.git/info/backlog-project.json` if it exists.
-  - Use the cache when: the file exists, `owner`/`repo` match, and `cached_at` is within 24 hours.
-  - On cache miss/expiry: query `gh project list --owner <owner> --format json` filtered by repo link; on success, refresh the cache (write to a temp file under `.git/info/`, then rename atomically).
-  - If neither cache nor live query find a Project:
-    - STOP
-    - Output exactly: `No Backlog project linked to <owner>/<repo>. Run /create-project first.`
+- Read `.claude/backlog-project.json`. If the file does not exist, STOP and output exactly:
+  `No Backlog project linked to <owner>/<repo>. Run /initialize-backlog first.`
 - Verify the canonical label catalog is present (`type:*`, `priority:*`, `effort:*`, `needs-clarification`):
   - `gh label list --limit 100`
-  - If any required label is missing, STOP and instruct the user to run `/create-project`
+  - If any required label is missing, STOP and instruct the user to run `/initialize-backlog`
 
 ---
 

--- a/commands/plan-release.md
+++ b/commands/plan-release.md
@@ -25,17 +25,10 @@ Create a GitHub Milestone for the next release, with:
 
 ### 1. Preflight (MANDATORY)
 
-The repository MUST already be provisioned by `create-project`. Detect:
+The repository MUST already be provisioned by `initialize-backlog`. Detect:
 
-- Run `gh auth status`. If not authenticated, STOP and instruct the user to run `gh auth login`.
-- Run `git remote get-url origin`. Parse `<owner>/<repo>`. STOP if missing.
-- Resolve project metadata, preferring the local cache:
-  - Read `.git/info/backlog-project.json` if it exists.
-  - Use the cache when: the file exists, `owner`/`repo` match, and `cached_at` is within 24 hours.
-  - On cache miss/expiry: query `gh project list --owner <owner> --format json` filtered by repo link; on success, refresh the cache (write to a temp file under `.git/info/`, then rename atomically).
-  - If neither cache nor live query find a Project:
-    - STOP
-    - Output exactly: `No Backlog project linked to <owner>/<repo>. Run /create-project first.`
+- Read `.claude/backlog-project.json`. If the file does not exist, STOP and output exactly:
+  `No Backlog project linked to <owner>/<repo>. Run /initialize-backlog first.`
 
 ---
 

--- a/commands/refine-backlog-item.md
+++ b/commands/refine-backlog-item.md
@@ -25,18 +25,11 @@ Bring the target issue to a fully refined state where:
 
 ### 0. Preflight (MANDATORY)
 
-- Run `gh auth status`. If not authenticated, STOP and instruct the user to run `gh auth login`.
-- Run `git remote get-url origin`. Parse `<owner>/<repo>`. STOP if missing.
-- Resolve project metadata, preferring the local cache:
-  - Read `.git/info/backlog-project.json` if it exists.
-  - Use the cache when: the file exists, `owner`/`repo` match, and `cached_at` is within 24 hours.
-  - On cache miss/expiry: query `gh project list --owner <owner> --format json` filtered by repo link; on success, refresh the cache (write to a temp file under `.git/info/`, then rename atomically).
-  - If neither cache nor live query find a Project:
-    - STOP
-    - Output exactly: `No Backlog project linked to <owner>/<repo>. Run /create-project first.`
+- Read `.claude/backlog-project.json`. If the file does not exist, STOP and output exactly:
+  `No Backlog project linked to <owner>/<repo>. Run /initialize-backlog first.`
 - Verify the canonical label catalog is present (`type:*`, `priority:*`, `effort:*`, `needs-clarification`):
   - `gh label list --limit 100`
-  - If any required label is missing, STOP and instruct the user to run `/create-project`
+  - If any required label is missing, STOP and instruct the user to run `/initialize-backlog`
 
 ---
 

--- a/commands/refine-backlog.md
+++ b/commands/refine-backlog.md
@@ -16,18 +16,11 @@ Walk every selected `needs-clarification` item in the linked Project through int
 
 ### 0. Preflight (MANDATORY)
 
-- Run `gh auth status`. If not authenticated, STOP and instruct the user to run `gh auth login`.
-- Run `git remote get-url origin`. Parse `<owner>/<repo>`. STOP if missing.
-- Resolve project metadata, preferring the local cache:
-  - Read `.git/info/backlog-project.json` if it exists.
-  - Use the cache when: the file exists, `owner`/`repo` match, and `cached_at` is within 24 hours.
-  - On cache miss/expiry: query `gh project list --owner <owner> --format json` filtered by repo link; on success, refresh the cache (write to a temp file under `.git/info/`, then rename atomically).
-  - If neither cache nor live query find a Project:
-    - STOP
-    - Output exactly: `No Backlog project linked to <owner>/<repo>. Run /create-project first.`
+- Read `.claude/backlog-project.json`. If the file does not exist, STOP and output exactly:
+  `No Backlog project linked to <owner>/<repo>. Run /initialize-backlog first.`
 - Verify the canonical label catalog is present (`type:*`, `priority:*`, `effort:*`, `needs-clarification`):
   - `gh label list --limit 100`
-  - If any required label is missing, STOP and instruct the user to run `/create-project`
+  - If any required label is missing, STOP and instruct the user to run `/initialize-backlog`
 
 ---
 

--- a/commands/validate-backlog.md
+++ b/commands/validate-backlog.md
@@ -25,15 +25,8 @@ Validate that the backlog:
 
 ### 0. Preflight (MANDATORY)
 
-- Run `gh auth status`. If not authenticated, STOP and instruct the user to run `gh auth login`.
-- Run `git remote get-url origin`. Parse `<owner>/<repo>`. STOP if missing.
-- Resolve project metadata, preferring the local cache:
-  - Read `.git/info/backlog-project.json` if it exists.
-  - Use the cache when: the file exists, `owner`/`repo` match, and `cached_at` is within 24 hours.
-  - On cache miss/expiry: query `gh project list --owner <owner> --format json` filtered by repo link; on success, refresh the cache (write to a temp file under `.git/info/`, then rename atomically). Audits are read-only on GitHub but MAY refresh the local cache.
-  - If neither cache nor live query find a Project:
-    - STOP
-    - Output exactly: `No Backlog project linked to <owner>/<repo>. Run /create-project first.`
+- Read `.claude/backlog-project.json`. If the file does not exist, STOP and output exactly:
+  `No Backlog project linked to <owner>/<repo>. Run /initialize-backlog first.`
 
 ---
 


### PR DESCRIPTION
## Summary

- **Rename `create-project` → `initialize-backlog`** — the new name reflects what the command actually does (bootstrapping the full backlog system: project, labels, Issue Forms template, and metadata file), not just "creating a project"
- **Move metadata file from `.git/info/backlog-project.json` to `.claude/backlog-project.json`** — makes the file tracked in version control, removes the 24-hour TTL and live-query fallback that required a network round-trip on every command invocation
- **Simplify preflight blocks in all 7 consumer commands** — the 8-line cache-read + live-query fallback is replaced by a direct 2-line file read; the metadata file is now the single source of truth with no fallback
- **Update project title convention** — from `<repo> Backlog` to `<owner>/<repo> Backlog` for unambiguous identification in multi-repo GitHub accounts
- Update all references in `CLAUDE.md`, `README.md`, and `SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)