### PR TITLE
refactor(invest-gate): enforce AC checklist format in Testable check

### DIFF
--- a/commands/add-backlog-item.md
+++ b/commands/add-backlog-item.md
@@ -84,7 +84,10 @@ Validate that the item is:
 - Valuable → Clear benefit to user or system
 - Estimable → Enough detail to assess complexity
 - Small → Can be delivered in a single iteration
-- Testable → Acceptance criteria are verifiable
+- Testable → Acceptance criteria are verifiable and in the correct format. **Format check (MANDATORY):** Every non-blank line in `### Acceptance Criteria` MUST begin with `- [ ]`. If any line does not match:
+  - STOP
+  - List each offending line and show its corrected `- [ ] <text>` form
+  - Propose corrected versions; require user approval before creation proceeds
 
 If any principle fails:
 

--- a/commands/refine-backlog-item.md
+++ b/commands/refine-backlog-item.md
@@ -106,7 +106,9 @@ Validate the refined item against:
 - Valuable
 - Estimable
 - Small
-- Testable
+- Testable — every non-blank line in `### Acceptance Criteria` MUST begin with `- [ ]`. If any line does not match:
+  - List each offending line and show its corrected `- [ ] <text>` form
+  - Propose corrected versions; require user approval before applying the body update
 
 If any principle still fails after refinement:
 


### PR DESCRIPTION
## Summary

- Extends the INVEST **Testable** check in `/add-backlog-item` to scan every non-blank line in `### Acceptance Criteria` and require `- [ ]` prefix
- Applies the same format check to `/refine-backlog-item`'s INVEST gate
- On failure: lists offending lines with corrected forms and gates on user approval before creation/refinement proceeds
- `/validate-backlog`'s AC format check is untouched (remains as secondary safety net)

## Test plan

- [ ] Create an item via `/add-backlog-item` with a free-form AC (e.g. `The feature works correctly`) — gate should STOP, list the offending line, propose `- [ ] The feature works correctly`, and block creation until approved
- [ ] Create an item with all ACs in `- [ ] <text>` format — gate should pass without interruption
- [ ] Refine a `needs-clarification` item that has a free-form AC — `/refine-backlog-item` INVEST gate should STOP and require correction before proceeding
- [ ] Confirm `/validate-backlog` still reports AC format violations independently

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)