### PR TITLE
docs: add Authentication & Permissions setup section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,84 @@ Restart Claude Code if it was already running. All commands below are then avail
 
 ---
 
+## Authentication & Permissions
+
+### 1. Authenticate the GitHub CLI
+
+If `gh auth status` reports that you are not logged in, run:
+
+```bash
+gh auth login
+```
+
+Choose **GitHub.com**, then **Login with a web browser** (recommended — it handles all scope grants in one step). If you prefer a token, select **Paste an authentication token** instead.
+
+### 2. Verify required token scopes
+
+This skill calls GitHub's Issues, Projects v2, and Dependencies APIs. Your token must include all four scopes:
+
+| Scope | Required for |
+|---|---|
+| `repo` | Create and read Issues, Labels, Milestones, and PRs |
+| `project` | Read and write GitHub Projects v2 |
+| `read:user` | Resolve the authenticated user for metadata |
+| `read:org` | Required when the repo lives under a GitHub organization |
+
+Check your current scopes:
+
+```bash
+gh auth status
+```
+
+If `project` or `read:user` are missing, add them without re-authenticating:
+
+```bash
+gh auth refresh --scopes project,read:user
+```
+
+> **Note:** `gh auth refresh` works for OAuth (web browser) logins. If you authenticated with a Personal Access Token, generate a new classic PAT on GitHub with the scopes listed above.
+
+### 3. Configure Claude Code permissions
+
+This skill runs multi-step workflows that call `gh` and `git` many times in sequence. Without a pre-approved allowlist, Claude Code prompts for permission on every call and interrupts the workflow mid-run.
+
+Add one of the blocks below to `.claude/settings.json` in any repo where you use this skill, or to `~/.claude/settings.json` for a global default.
+
+**YOLO mode — no prompts during any multi-step command:**
+
+```json
+{
+  "permissions": {
+    "allow": ["Bash(gh *)", "Bash(git *)"]
+  }
+}
+```
+
+**Safe / read-only mode — `/validate-backlog` and read queries run silently; write commands still ask for confirmation:**
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh auth status *)",
+      "Bash(gh repo view *)",
+      "Bash(gh issue list *)",
+      "Bash(gh issue view *)",
+      "Bash(gh label list *)",
+      "Bash(gh project list *)",
+      "Bash(gh project view *)",
+      "Bash(gh project item-list *)",
+      "Bash(gh project field-list *)",
+      "Bash(gh release list *)"
+    ]
+  }
+}
+```
+
+> **Note:** `gh api` calls used for reading milestones and issue dependencies are not listed above — the same command prefix covers both reads and writes, so they cannot be cleanly separated by pattern. In safe mode these calls will still prompt; approve them when the command starts with `gh api "repos/..."` and contains no `-X POST` or `-X DELETE` flag.
+
+---
+
 ## Features
 
 | Command | What it does |


### PR DESCRIPTION
## Summary

- Adds a new **Authentication & Permissions** section to the README, inserted between Installation and Features
- Covers the three setup steps a first-time user needs before running `/initialize-backlog`: `gh auth login` walkthrough, required token scopes table, and Claude Code `allowedTools` config examples
- Two config modes documented: YOLO (`Bash(gh *)` + `Bash(git *)`) and safe/read-only (explicit list of read-only `gh` subcommands), with a note on why `gh api` calls cannot be cleanly pre-approved in safe mode

## Acceptance Criteria

- [x] README has an "Authentication" subsection covering `gh auth login` and scope requirements
- [x] Table shows all four required scopes (`repo`, `project`, `read:user`, `read:org`) with one-line explanations
- [x] YOLO mode `allowedTools` config snippet included
- [x] Safe-mode config snippet included with read-only `gh` subcommands only
- [x] A first-time user can follow only the README to reach `/initialize-backlog` without hitting an undocumented auth or permission error

## Notes

The `allowedTools` patterns in the safe-mode snippet were derived by auditing all `gh` calls across every command file in `commands/`. The `gh api` entry is intentionally omitted from safe mode — the same prefix covers both GET and POST/DELETE calls and cannot be split by pattern alone. The note in the section explains how to approve these case-by-case.

Closes #14

🤖 Generated with [Claude Code](https://claude.ai/claude-code)