### PR TITLE
chore(ci): add tag-triggered release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build release zip
+        run: |
+          ZIP_NAME="github-backlog-management-${GITHUB_REF_NAME}.zip"
+          mkdir github-backlog-management
+          cp -r commands/ README.md SKILL.md LICENSE github-backlog-management/
+          zip -r "${ZIP_NAME}" github-backlog-management/
+          echo "ZIP_NAME=${ZIP_NAME}" >> "$GITHUB_ENV"
+
+      - name: Upload zip to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${GITHUB_REF_NAME}" "${ZIP_NAME}"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yaml` triggered on `push: tags: v*`
- Packages `commands/`, `README.md`, `SKILL.md`, and `LICENSE` into a `github-backlog-management/` top-level folder inside `github-backlog-management-<tag>.zip`
- Uploads the zip as an asset to the existing GitHub Release under that tag using `gh release upload` and `GITHUB_TOKEN` only

Closes #15

## Test plan

- [ ] Push a `v*` tag to a repo with an existing GitHub Release and verify the workflow triggers
- [ ] Confirm the workflow completes and the zip asset appears on the Release page
- [ ] Unzip the asset and verify the `github-backlog-management/` folder contains `commands/` (8 `.md` files), `README.md`, `SKILL.md`, and `LICENSE`
- [ ] Confirm `CLAUDE.md`, `.github/`, `evals/`, `.claude/`, and `.git/` are absent from the zip
- [ ] Confirm no secrets beyond `GITHUB_TOKEN` are required

🤖 Generated with [Claude Code](https://claude.com/claude-code)