### PR TITLE
feat: add Claude Marketplace plugin manifest and installation docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "gringolito",
+  "description": "Plugins by Filipe Utzig",
+  "owner": {
+    "name": "Filipe Utzig",
+    "email": "filipe@gringolito.com"
+  },
+  "plugins": [
+    {
+      "name": "github-backlog-management",
+      "description": "GitHub-native backlog automation. Manage Issues + Projects v2 with AI-enforced INVEST quality, dependency tracking, and one-command execution.",
+      "source": {
+        "source": "github",
+        "repo": "gringolito/github-backlog-management-skill"
+      },
+      "version": "0.1.0",
+      "category": "productivity"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "github-backlog-management",
+  "description": "GitHub-native backlog automation. Manage Issues + Projects v2 with AI-enforced INVEST quality, dependency tracking, and one-command execution.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Filipe Utzig",
+    "email": "filipe@gringolito.com"
+  },
+  "homepage": "https://github.com/gringolito/github-backlog-management-skill",
+  "repository": "https://github.com/gringolito/github-backlog-management-skill",
+  "license": "MIT",
+  "commands": "./commands"
+}

--- a/README.md
+++ b/README.md
@@ -38,13 +38,26 @@ Run `/migrate-backlog`, point Claude at the file, and it imports everything into
 
 ## Installation
 
-Clone this repository into Claude Code's skills directory:
+### Native plugin install (recommended)
+
+Add the marketplace and install the plugin with two Claude Code commands:
+
+```text
+/plugin marketplace add gringolito/github-backlog-management-skill
+/plugin install github-backlog-management@gringolito
+```
+
+Restart Claude Code if it was already running. All commands below are then available in any repository you open with Claude Code.
+
+### Manual install (fallback)
+
+If your version of Claude Code does not support the plugin system, clone directly into the skills directory:
 
 ```bash
 git clone https://github.com/gringolito/github-backlog-management-skill.git ~/.claude/skills/github-backlog-management
 ```
 
-Restart Claude Code if it was already running. All commands below are then available in any repository you open with Claude Code.
+Restart Claude Code if it was already running.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/marketplace.json` — registers this repo as a single-plugin marketplace named `gringolito`
- Adds `.claude-plugin/plugin.json` — plugin manifest pointing `commands` at `./commands` so all 8 slash commands are available on install
- Updates `README.md` Installation section: native plugin install is now the primary path, git clone demoted to a manual fallback

## Install flow (after merge)

```text
/plugin marketplace add gringolito/github-backlog-management-skill
/plugin install github-backlog-management@gringolito
```

## Test plan

- [ ] Run `/plugin marketplace add gringolito/github-backlog-management-skill` — succeeds without error
- [ ] Run `/plugin install github-backlog-management@gringolito` — installs successfully
- [ ] All 8 commands (`/initialize-backlog`, `/plan-release`, `/add-backlog-item`, `/migrate-backlog`, `/refine-backlog`, `/refine-backlog-item`, `/validate-backlog`, `/execute-backlog-item`) are available after install
- [ ] README Installation section documents both install paths
- [ ] `.claude-plugin/marketplace.json` validates against the SchemaStore schema

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)