### PR TITLE
refactor(refine-backlog-item): add effort consistency check to pre-removal gate

### DIFF
--- a/commands/refine-backlog-item.md
+++ b/commands/refine-backlog-item.md
@@ -216,6 +216,7 @@ Run all of the following checks:
 - **Project Status set** — the item has a non-empty Status value in the Project
 - **INVEST re-check** — re-evaluate the final live body (not the in-memory draft) against all six INVEST principles
 - **INVEST Notes clear** — `### INVEST Notes` is either empty or contains only acknowledged residual questions with no open action items
+- **Effort consistency** — assess whether the current `effort:*` label still fits the refined `### In Scope` and `### Acceptance Criteria`, using the same relative heuristics as step 7. If the label appears inconsistent with the refined scope: gate fails, explain the mismatch, and suggest the likely correct effort label. The user must correct the label (via step 7 flow) before the gate can pass.
 
 If ANY check fails:
 


### PR DESCRIPTION
## Summary

- Extends the step 9 pre-removal validation gate in `/refine-backlog-item` with an **Effort consistency** check
- Gate now assesses whether the current `effort:*` label still fits the refined `### In Scope` and `### Acceptance Criteria` using the same relative heuristics as step 7
- If inconsistent: gate fails with an explanation and suggests the likely correct label; user corrects via step 7 flow before retrying

## Test plan

- [ ] Refine an item where scope narrows significantly during discovery — verify gate catches stale `effort:L/XL` and suggests smaller label
- [ ] Refine an item where scope expands — verify gate catches under-sized effort label
- [ ] Refine an item where effort label accurately reflects refined scope — verify gate passes without false positive
- [ ] Trigger a gate failure on this check — confirm message explains the mismatch and suggests correct label
- [ ] Confirm all other pre-removal gate checks are unaffected

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)