### PR TITLE
feat(release-status): add read-only milestone health dashboard command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,12 @@ There is **no source code, no build, no tests, no lint**. Each command file is a
 initialize-backlog   ─►  plan-release   ─►  add-backlog-item / migrate-backlog
                                                   │
                                                   ├─►  refine-backlog ─► refine-backlog-item   (needs-clarification)
+                                                  ├─►  release-status                          (read-only dashboard)
                                                   ├─►  validate-backlog                        (read-only audit)
                                                   └─►  execute-backlog-item                    (picks topmost unblocked)
 ```
 
-`initialize-backlog` is the bootstrap. Every other command preflights for a Project linked to the repo and stops with the standard error if missing. `plan-release` creates Milestones (releases). `add-backlog-item` and `migrate-backlog` create Issues. `execute-backlog-item` picks work. `refine-backlog` orchestrates a session over items flagged `needs-clarification`, delegating each to `refine-backlog-item`. `validate-backlog` audits without mutating.
+`initialize-backlog` is the bootstrap. Every other command preflights for a Project linked to the repo and stops with the standard error if missing. `plan-release` creates Milestones (releases). `add-backlog-item` and `migrate-backlog` create Issues. `execute-backlog-item` picks work. `refine-backlog` orchestrates a session over items flagged `needs-clarification`, delegating each to `refine-backlog-item`. `release-status` produces a read-only milestone health dashboard. `validate-backlog` audits without mutating.
 
 ## Invariants that MUST be preserved across all commands
 
@@ -28,7 +29,7 @@ When editing any command, these must stay consistent across files. Most consiste
 grep -hoE "type:[a-z-]+" commands/*.md | sort -u           # 9 type labels
 grep -hoE "priority:P[0-3]" commands/*.md | sort -u         # 4 priority labels
 grep -hoE "effort:(XS|S|M|L|XL)\b" commands/*.md | sort -u  # 5 effort labels
-grep -n "No Backlog project linked" commands/*.md           # identical preflight stop string in 7 files
+grep -n "No Backlog project linked" commands/*.md           # identical preflight stop string in 8 files
 grep -n ".claude/backlog-project.json" commands/*.md        # metadata file referenced everywhere
 ```
 
@@ -40,7 +41,7 @@ grep -n ".claude/backlog-project.json" commands/*.md        # metadata file refe
 
 4. **Metadata file location** — `.claude/backlog-project.json`. `initialize-backlog` writes it; all other commands read it directly with no live-query fallback. Schema documented in `initialize-backlog.md`.
 
-5. **Active milestone resolution** — earliest open `due_on`, tie-break by lowest version parsed from milestone title (`v1.2.0` < `v1.3.0`), fallback to milestone `number` for non-parseable titles. When no milestone has `due_on`, lowest version wins. This logic must match in `execute-backlog-item` and `add-backlog-item`.
+5. **Active milestone resolution** — earliest open `due_on`, tie-break by lowest version parsed from milestone title (`v1.2.0` < `v1.3.0`), fallback to milestone `number` for non-parseable titles. When no milestone has `due_on`, lowest version wins. This logic must match in `execute-backlog-item`, `add-backlog-item`, and `release-status`.
 
 6. **Priority label vs Project rank** — these are independent concepts. `priority:*` is severity classification. Execution order is the manual rank in the Project's `Todo` column (top wins). `add-backlog-item` does relative analysis on BOTH and recommends keeping them consistent, but `execute-backlog-item` sorts by rank ONLY and ignores the priority label for ordering. Don't conflate.
 
@@ -75,5 +76,6 @@ There is no automated test suite. The end-to-end smoke is:
 3. `/add-backlog-item` → issue with all three label groups, body matches template, item in Project at the chosen rank with Status=Todo, deps applied if declared.
 4. `/migrate-backlog` against a small sample BACKLOG.md including a Done item → Done item skipped, others migrated, dep inference candidates reviewed.
 5. `/execute-backlog-item` → picks topmost unblocked item, surfaces skipped-because-blocked items above it.
-6. `/validate-backlog` → seed deliberate violations (missing `priority:*`, dangling blocker, cross-Project blocker) and confirm they appear in the Critical/Quality/Consistency report sections.
-7. `/refine-backlog` → presents the `needs-clarification` queue, user selects items, loop delegates to `/refine-backlog-item`; label removed only after pre-removal validation gate passes.
+6. `/release-status` → confirm Markdown dashboard renders with correct counts by Status, blocked-items section (or graceful omission on `404`), and unestimated list; run again with an explicit milestone argument and verify it resolves correctly.
+7. `/validate-backlog` → seed deliberate violations (missing `priority:*`, dangling blocker, cross-Project blocker) and confirm they appear in the Critical/Quality/Consistency report sections.
+8. `/refine-backlog` → presents the `needs-clarification` queue, user selects items, loop delegates to `/refine-backlog-item`; label removed only after pre-removal validation gate passes.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Add one of the blocks below to `.claude/settings.json` in any repo where you use
 | `/migrate-backlog` | Bulk-imports an existing `BACKLOG.md`. Skips Done items. Dependency inference is opt-in — candidates are reviewed before anything is applied. |
 | `/refine-backlog` | Lists all `needs-clarification` candidates, lets you select which to refine, then loops through them one by one — asking continue/stop after each. |
 | `/refine-backlog-item` | Refines a single `needs-clarification` item: discovery dialogue, body rewrite, INVEST gate, label/rank/dep re-evaluation, and label removal after a final validation pass. |
+| `/release-status` | Read-only milestone health dashboard — issue counts by Project Status, % complete, blocked items, and unestimated items. Accepts an optional milestone argument; defaults to the active milestone. |
 | `/validate-backlog` | Read-only audit. Emits actionable `gh issue edit ...` snippets. Never mutates anything. |
 | `/execute-backlog-item` | Picks the topmost unblocked Todo item, respects active milestone scope, skips blocked items, and walks you through to a PR. |
 
@@ -195,6 +196,7 @@ Priority is severity classification. Execution order is the manual Project rank 
                                           /migrate-backlog
                                                 │
                                                 ├──► /refine-backlog ──► /refine-backlog-item
+                                                ├──► /release-status    (read-only)
                                                 ├──► /validate-backlog  (read-only)
                                                 └──► /execute-backlog-item
 ```
@@ -250,6 +252,20 @@ Lists all `needs-clarification` items sorted by priority, lets you select which 
 ```
 
 Refines a single item directly (useful when you know exactly which issue needs attention). Guides a discovery dialogue, rewrites the body, re-evaluates labels and rank, runs a validation gate, and removes `needs-clarification` only when everything checks out.
+
+### Checking release health
+
+```
+/release-status
+```
+
+Produces a Markdown dashboard for the active milestone: issue counts by Project Status (Done / In Progress / Todo), % complete, blocked items (requires GitHub's native dependency API), and open items missing an `effort:*` label. Pass a milestone title, number, or version string to target a specific release:
+
+```
+/release-status v1.3.0
+```
+
+The output is valid GitHub-Flavored Markdown — paste it directly into a standup document, Slack message, or GitHub comment.
 
 ### Auditing backlog health
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -19,6 +19,7 @@ A set of slash commands for a fully GitHub-native backlog workflow — Issues, P
 | `/migrate-backlog` | Bulk-import an existing backlog file; skips Done items; dep inference opt-in |
 | `/refine-backlog` | Orchestrate a refinement session: list `needs-clarification` candidates, let user select, loop through with `/refine-backlog-item` |
 | `/refine-backlog-item` | Refine a single `needs-clarification` item — discovery dialogue, body rewrite, INVEST gate, label/rank/dep updates, label removal |
+| `/release-status` | Read-only milestone health dashboard — issue counts by Status, blocked items, unestimated items |
 | `/validate-backlog` | Read-only audit — emits actionable `gh` commands; never mutates |
 | `/execute-backlog-item` | Pick the topmost unblocked Todo item and guide it through to a PR |
 
@@ -28,6 +29,7 @@ A set of slash commands for a fully GitHub-native backlog workflow — Issues, P
 initialize-backlog ─► plan-release ─► add-backlog-item / migrate-backlog
                                               │
                                               ├─► refine-backlog ─► refine-backlog-item
+                                              ├─► release-status (read-only)
                                               ├─► validate-backlog (read-only)
                                               └─► execute-backlog-item
 ```

--- a/commands/release-status.md
+++ b/commands/release-status.md
@@ -1,0 +1,143 @@
+# release-status
+
+You are an AI agent acting as a release manager responsible for producing a real-time health dashboard for a GitHub Milestone.
+
+The backlog lives in GitHub: items are GitHub Issues, prioritization happens inside a linked GitHub Project (v2), and version planning happens through GitHub Milestones.
+
+This command is **read-only** — it never mutates issues, labels, projects, or milestones.
+
+---
+
+## Objective
+
+Produce a Markdown release health dashboard for a target milestone: issue counts by Project Status, percentage complete, blocked items, and unestimated items — aggregated from a single command with zero manual querying.
+
+---
+
+## Workflow
+
+### 0. Preflight (MANDATORY)
+
+- Read `.claude/backlog-project.json`. If the file does not exist, STOP and output exactly:
+  `No Backlog project linked to <owner>/<repo>. Run /initialize-backlog first.`
+
+---
+
+### 1. Milestone Resolution (MANDATORY)
+
+The command accepts an optional milestone argument (title substring, number, or version string).
+
+**With argument** — resolve from open milestones via `gh api "repos/<owner>/<repo>/milestones?state=open&per_page=100"`:
+
+1. If the argument is a plain integer, match by milestone `number`.
+2. Otherwise, match by case-insensitive substring of `title`.
+3. If no substring match, try version string matching: strip a leading `v` from both the argument and each `title` before comparing (e.g. `1.2.0` matches `v1.2.0`).
+4. If no match is found after all three passes, STOP and output: `No open milestone matching "<argument>" found.`
+
+**Without argument** — use the canonical active-milestone logic:
+
+- Primary sort: `due_on` ascending; milestones with no `due_on` are sorted last.
+- Tie-break: lowest version parsed from milestone `title` (`v1.2.0` < `v1.3.0`; for non-parseable titles, fall back to milestone `number` ascending).
+- If NO open milestones exist, STOP and output: `No open milestones found.`
+
+---
+
+### 2. Data Collection (MANDATORY)
+
+With the resolved milestone in hand, run these queries:
+
+1. **Issues assigned to the milestone**:
+   `gh issue list --state all --milestone "<milestone-title>" --json number,title,labels,state,url --limit 500`
+
+2. **Project membership and Status**:
+   `gh project item-list <project-number> --owner <owner> --format json`
+   Build a lookup map: issue `number` → Project `Status` (`Todo` / `In Progress` / `Done`). Issues absent from the map are classified as "Not in Project."
+
+3. **Blocker check** (open issues only):
+   For each open issue, call: `gh api "repos/<owner>/<repo>/issues/<n>/dependencies/blocked_by"`
+   - If the API returns `404` on the first call, emit exactly once: `Issue Dependencies API unavailable on this repo — blocked items section omitted.` Skip the blocked-items section for the entire report.
+   - An issue is **blocked** if the response contains at least one blocker with `state == "open"`.
+
+4. **Unestimated check**:
+   For each issue, scan its labels for any `effort:*` label. Issues with none are unestimated.
+
+---
+
+### 3. Report Assembly (MANDATORY)
+
+Produce a Markdown report with the following sections in this exact order.
+
+#### Header
+
+```
+## Release Status: <milestone-title>
+Due: <due_on as YYYY-MM-DD> | Total: <N> issues
+```
+
+Omit the `Due:` line if the milestone has no `due_on`.
+
+#### Progress
+
+| Status | Count | % of Total |
+|--------|-------|------------|
+| ✅ Done | N | N% |
+| 🔄 In Progress | N | N% |
+| 📋 Todo | N | N% |
+| ⚠️ Not in Project | N | — |
+
+- **% complete** = Done ÷ (all issues assigned to the milestone), rounded to the nearest integer.
+- Omit the "Not in Project" row if its count is 0.
+
+#### Blocked Items
+
+_Omit this section entirely if the Dependencies API is unavailable._
+
+If no open issues are blocked:
+> ✅ No blocked items.
+
+Otherwise:
+
+| Issue | Title | Blocked by |
+|-------|-------|------------|
+| [#N](\<url\>) | title | [#M](\<url\>), … |
+
+#### Unestimated Items
+
+If all open issues carry an `effort:*` label:
+> ✅ All open items are estimated.
+
+Otherwise, a bulleted list of open issues missing `effort:*`:
+
+- `#N` — title (`<Status>`)
+
+#### All Issues
+
+Issues grouped by Status:
+
+**✅ Done (N)**
+- [x] [#N](\<url\>) — title
+
+**🔄 In Progress (N)**
+- [ ] [#N](\<url\>) — title
+
+**📋 Todo (N)**
+- [ ] [#N](\<url\>) — title
+
+**⚠️ Not in Project (N)** _(omit section if 0)_
+- [ ] [#N](\<url\>) — title
+
+---
+
+## Rules & Constraints
+
+- This command is **strictly read-only** — never mutate any issue, Project field, milestone, or label.
+- Surface all `gh` errors verbatim — never swallow.
+- Issue Dependencies API `404` must emit one warning line and gracefully skip the blocked-items section; it must not abort the rest of the report.
+- % complete is always computed over ALL issues assigned to the milestone, not just those in the Project.
+- Do NOT pick or recommend execution order — this command surfaces state only.
+
+---
+
+## Output Expectations
+
+The entire output is the Markdown report — no preamble, no trailing summary, no conversational wrapping. The report must be valid GitHub-Flavored Markdown so the user can paste it directly into a standup document, Slack message, or GitHub comment.


### PR DESCRIPTION
## Summary

- Adds `commands/release-status.md` — a new read-only command spec for `/release-status`
- Registers the command in `SKILL.md` routing table and workflow diagram
- Updates `CLAUDE.md` with invariant note, preflight count, and smoke test step
- Updates `README.md` with features table entry, workflow diagram, and usage section

## What the command does

`/release-status` produces a GitHub-Flavored Markdown dashboard for a target milestone:

- **Progress table** — issue counts by Project Status (Done / In Progress / Todo / Not in Project) with % complete
- **Blocked items** — per-issue blocker list via the native dependency API; graceful one-line warning on `404`
- **Unestimated items** — open issues missing an `effort:*` label
- **All issues grouped by Status** — full checklist view

Accepts an optional milestone argument (title substring, number, or version string); defaults to the active milestone via the canonical resolution logic shared with `execute-backlog-item` and `add-backlog-item`.

## Acceptance Criteria coverage

| AC | Covered by |
|----|------------|
| Preflight stop | Step 0 |
| Active milestone canonical logic | Step 1 (without arg) |
| Milestone arg resolution + error | Step 1 (with arg) |
| Status counts + % complete | Steps 2+3 |
| Blocked items section (or API warning) | Steps 2+3 |
| Unestimated items section | Steps 2+3 |
| Valid GFM Markdown output | Step 3 |
| Strictly read-only | No mutation calls anywhere |

## Test plan

- [ ] Run `/release-status` with no arg — verify active milestone is resolved (v0.2.0) and dashboard renders with correct counts
- [ ] Run `/release-status v0.2.0` — verify milestone arg resolves by version string
- [ ] Run `/release-status 999` — verify "No open milestone matching" error
- [ ] Confirm blocked-items section renders (or the graceful API-unavailable warning appears)
- [ ] Confirm unestimated items section lists any issues missing `effort:*`
- [ ] Confirm output is pasteable GFM with no preamble or conversational wrapping

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)