### PR TITLE
feat(external-blocker): add type:external-blocker to label catalog and provision in initialize-backlog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,14 +26,14 @@ initialize-backlog   ─►  plan-release   ─►  add-backlog-item / migrate-b
 When editing any command, these must stay consistent across files. Most consistency violations are caught by:
 
 ```bash
-grep -hoE "type:[a-z-]+" commands/*.md | sort -u           # 9 type labels
+grep -hoE "type:[a-z-]+" commands/*.md | sort -u           # 10 type labels
 grep -hoE "priority:P[0-3]" commands/*.md | sort -u         # 4 priority labels
 grep -hoE "effort:(XS|S|M|L|XL)\b" commands/*.md | sort -u  # 5 effort labels
 grep -n "No Backlog project linked" commands/*.md           # identical preflight stop string in 8 files
 grep -n ".claude/backlog-project.json" commands/*.md        # metadata file referenced everywhere
 ```
 
-1. **Label catalog** — `type:{feature,bug,security,performance,dx,tech-debt,reliability,compliance,spike}`, `priority:{P0,P1,P2,P3}`, `effort:{XS,S,M,L,XL}`, plus `needs-clarification`. Any new value or rename must be applied in all command files.
+1. **Label catalog** — `type:{feature,bug,security,performance,dx,tech-debt,reliability,compliance,spike,external-blocker}`, `priority:{P0,P1,P2,P3}`, `effort:{XS,S,M,L,XL}`, plus `needs-clarification`. Any new value or rename must be applied in all command files. `type:external-blocker` is infrastructure-only — never assigned to work items.
 
 2. **Standard preflight stop string** — every consumer command outputs *exactly* `No Backlog project linked to <owner>/<repo>. Run /initialize-backlog first.` when the metadata file is missing.
 

--- a/README.md
+++ b/README.md
@@ -181,13 +181,17 @@ Every issue created by this skill follows a consistent body shape:
 ### INVEST Notes
 ```
 
-Every issue carries three label groups:
+Every backlog item carries three label groups:
 
 - **Type** — `type:feature` `type:bug` `type:security` `type:performance` `type:dx` `type:tech-debt` `type:reliability` `type:compliance` `type:spike`
 - **Priority** — `priority:P0` through `priority:P3`
 - **Effort** — `effort:XS` `effort:S` `effort:M` `effort:L` `effort:XL`
 
 Priority is severity classification. Execution order is the manual Project rank — the two are independent concepts that should stay consistent but are never conflated.
+
+#### External blocker stubs
+
+`type:external-blocker` is a special infrastructure label for lightweight stub issues that represent external constraints (API limitations, vendor issues, regulatory holds, etc.) blocking one or more backlog items. Stubs carry **only** the `type:external-blocker` label — no priority, no effort, no rank. They are created by `/add-external-blocker`, never appear as executable work in `/execute-backlog-item`, and are excluded from all milestone counts and planning scope. Close a stub with `/resolve-external-blocker` when the external constraint is lifted.
 
 ### Workflow
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -39,7 +39,7 @@ initialize-backlog ─► plan-release ─► add-backlog-item / migrate-backlog
 ## Key Invariants (apply to all commands)
 
 **Label catalog**
-- `type:` — `feature` `bug` `security` `performance` `dx` `tech-debt` `reliability` `compliance` `spike`
+- `type:` — `feature` `bug` `security` `performance` `dx` `tech-debt` `reliability` `compliance` `spike` `external-blocker`
 - `priority:` — `P0` `P1` `P2` `P3`
 - `effort:` — `XS` `S` `M` `L` `XL`
 - Operational: `needs-clarification`

--- a/commands/add-backlog-item.md
+++ b/commands/add-backlog-item.md
@@ -50,6 +50,7 @@ Before any item work, verify the repository is provisioned:
   - Reliability (`type:reliability`)
   - Compliance (`type:compliance`)
   - Spike (`type:spike`)
+- `type:external-blocker` is reserved for infrastructure stubs created by `/add-external-blocker` — DO NOT classify work items with this type; if the user attempts to, STOP and redirect them to `/add-external-blocker`
 - If classification is unclear → STOP and ask for clarification
 
 ---

--- a/commands/initialize-backlog.md
+++ b/commands/initialize-backlog.md
@@ -89,6 +89,7 @@ Create the standard label catalog. Use `gh label create --force` so existing lab
 - `type:reliability`
 - `type:compliance`
 - `type:spike`
+- `type:external-blocker`
 
 #### Priority labels (one of these must be on every backlog item)
 
@@ -137,15 +138,16 @@ If the file is missing or the user approved replacement:
 - Create a branch: `chore/backlog-item-issue-template`
   - `git checkout -b chore/backlog-item-issue-template`
 - Create the parent directory if needed: `mkdir -p .github/ISSUE_TEMPLATE`
-- Write the canonical contents below to `.github/ISSUE_TEMPLATE/backlog-item.yml`
-- Commit using Conventional Commits:
-  - `git add .github/ISSUE_TEMPLATE/backlog-item.yml`
-  - `git commit -m "chore: add backlog-item issue forms template"`
+- Write the canonical contents of §5c below to `.github/ISSUE_TEMPLATE/backlog-item.yml`
+- Write the canonical contents of §5d below to `.github/ISSUE_TEMPLATE/external-blocker.yml`
+- Commit both files using Conventional Commits:
+  - `git add .github/ISSUE_TEMPLATE/backlog-item.yml .github/ISSUE_TEMPLATE/external-blocker.yml`
+  - `git commit -m "chore: add backlog-item and external-blocker issue forms templates"`
 - Push the branch: `git push -u origin chore/backlog-item-issue-template`
-- Open a PR via `gh pr create --title "chore: add backlog-item issue forms template" --body "<body>"` where the body explains:
-  - This template is the canonical body shape for backlog-item issues
-  - All `add-backlog-item`, `migrate-backlog` commands depend on these section headings (`### What`, `### Why`, `### In Scope`, `### Out of Scope`, `### Acceptance Criteria`, `### INVEST Notes`)
-  - `validate-backlog` parses these sections — changing them will break parsing
+- Open a PR via `gh pr create --title "chore: add backlog-item and external-blocker issue forms templates" --body "<body>"` where the body explains:
+  - `backlog-item.yml` is the canonical body shape for backlog items — all commands depend on its section headings
+  - `external-blocker.yml` is the template for infrastructure stub issues created by `/add-external-blocker`
+  - `validate-backlog` parses `backlog-item.yml` sections — changing them will break parsing
 - Print the PR URL
 
 The remaining provisioning steps (project, labels) are NOT gated by this PR — they are direct API calls. The template only takes effect on the default branch after the PR is merged. Until then, `add-backlog-item` and `migrate-backlog` will still emit issue bodies in the canonical shape (the template is for human use in the GitHub UI).
@@ -214,6 +216,42 @@ body:
 ```
 
 The rendered issue body produced by GitHub for this template uses `### What`, `### Why`, `### In Scope`, `### Out of Scope`, `### Acceptance Criteria`, `### INVEST Notes` headings. All other commands MUST emit bodies that use these exact headings (case + ordering preserved).
+
+#### 5d. Canonical contents — external-blocker.yml
+
+```yaml
+name: External Blocker
+description: Record an external constraint (API limitation, vendor issue, regulatory hold, etc.) blocking a backlog item
+title: "External blocker: "
+labels: ["type:external-blocker"]
+body:
+  - type: textarea
+    id: reason
+    attributes:
+      label: Reason
+      description: What external constraint is causing the block?
+      placeholder: e.g. "Vendor API does not support X; waiting for SDK v3 release"
+    validations:
+      required: true
+  - type: input
+    id: external-reference
+    attributes:
+      label: External Reference / URL
+      description: Link to vendor issue, RFC, ticket, or documentation (optional).
+      placeholder: https://...
+    validations:
+      required: false
+  - type: textarea
+    id: resolution-path
+    attributes:
+      label: Expected Resolution Path
+      description: How is this expected to be resolved? (optional)
+      placeholder: e.g. "Monitor vendor release notes; re-evaluate in next sprint"
+    validations:
+      required: false
+```
+
+This template pre-applies the `type:external-blocker` label. There is no "Blocked Item" field — a single stub can block multiple items, and GitHub tracks blocking relationships natively via the Issue Dependencies API.
 
 ---
 

--- a/commands/migrate-backlog.md
+++ b/commands/migrate-backlog.md
@@ -57,7 +57,7 @@ If item boundaries are unclear:
 For EACH item, derive the GitHub-native representation:
 
 - **Title** — concise; will be issue title
-- **Type** — exactly one type label (`type:feature`, `type:bug`, `type:security`, `type:performance`, `type:dx`, `type:tech-debt`, `type:reliability`, `type:compliance`, `type:spike`)
+- **Type** — exactly one type label (`type:feature`, `type:bug`, `type:security`, `type:performance`, `type:dx`, `type:tech-debt`, `type:reliability`, `type:compliance`, `type:spike`); never `type:external-blocker` — stubs are infrastructure and are never migrated from backlog files
 - **Priority** — exactly one priority label (`priority:P0` / `priority:P1` / `priority:P2` / `priority:P3`)
 - **Effort** — exactly one effort label (`effort:XS` / `effort:S` / `effort:M` / `effort:L` / `effort:XL`) — complexity-based, NOT time
 - **Body sections** (matching the Issue Forms template at `.github/ISSUE_TEMPLATE/backlog-item.yml`):

--- a/commands/validate-backlog.md
+++ b/commands/validate-backlog.md
@@ -55,7 +55,7 @@ For EACH issue in the Project, verify:
 
 #### Labels (exactly-one rule)
 
-- Exactly one `type:*` label from the canonical set
+- Exactly one `type:*` label from the canonical set (`type:feature`, `type:bug`, `type:security`, `type:performance`, `type:dx`, `type:tech-debt`, `type:reliability`, `type:compliance`, `type:spike`, `type:external-blocker`)
 - Exactly one `priority:*` label from {`priority:P0`, `priority:P1`, `priority:P2`, `priority:P3`}
 - Exactly one `effort:*` label from {`effort:XS`, `effort:S`, `effort:M`, `effort:L`, `effort:XL`}
 


### PR DESCRIPTION
## Summary

- Adds `type:external-blocker` to the type label list in `initialize-backlog.md` and extends step 5b to ship `external-blocker.yml` alongside `backlog-item.yml` in the same template PR
- Adds §5d with canonical `external-blocker.yml` template contents (Reason required; External Reference/URL and Expected Resolution Path optional; label pre-applied; no Blocked Item field)
- Adds `type:external-blocker` to the explicit canonical set in `validate-backlog.md` so stubs aren't flagged as unknown labels
- Guards `add-backlog-item.md` and `migrate-backlog.md` against misuse of the stub type on work items
- Updates `CLAUDE.md` invariant (9→10 type labels), `README.md` with a dedicated external-blocker stubs section, and `SKILL.md` label catalog

## Test plan

- [ ] `grep -hoE "type:[a-z-]+" commands/*.md | sort -u` includes `type:external-blocker`
- [ ] `grep -nE "[Bb]ucket" commands/*.md` returns empty
- [ ] README "External blocker stubs" section clearly communicates stubs carry only `type:external-blocker` (no priority/effort)
- [ ] `initialize-backlog.md` §5b and §5d describe both templates being committed and shipped in the same PR

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)