### PR TITLE
feat(external-blocker): add /block-backlog-item, /add-external-blocker, /resolve-external-blocker commands

### DIFF
--- a/commands/add-backlog-item.md
+++ b/commands/add-backlog-item.md
@@ -221,9 +221,11 @@ The current issue's `id` was returned by `gh issue create`; capture it. For cros
 
 #### 9b. Apply "blocked by" relationships
 
-For each blocker the user named in step 1:
+For each blocker the user named in step 1, delegate to `/block-backlog-item`:
 
-- `gh api -X POST "repos/<owner>/<repo>/issues/<this-number>/dependencies/blocked_by" -f issue_id=<blocker-id>`
+```text
+/block-backlog-item #<this-number> #<blocker-number>
+```
 
 GitHub allows up to 50 blockers per direction and prevents cycles automatically. Cross-Project blockers ARE permitted — they will be flagged as a smell by `validate-backlog` but not rejected here.
 

--- a/commands/add-external-blocker.md
+++ b/commands/add-external-blocker.md
@@ -94,38 +94,14 @@ Do NOT add the stub to the linked Project, do NOT assign a milestone, do NOT ass
 
 ### 4. Dependency Registration (STRICT)
 
-Resolve the database IDs of both issues:
+Delegate to `/block-backlog-item` to register the stub as a blocker of `#N`:
 
 ```
-gh api "repos/<owner>/<repo>/issues/<N>" --jq '.id'
-gh api "repos/<owner>/<repo>/issues/<stub>" --jq '.id'
+/block-backlog-item #<N> #<stub>
 ```
 
-Register the stub as a blocker of `#N`:
 
-```
-gh api -X POST "repos/<owner>/<repo>/issues/<N>/dependencies/blocked_by" \
-  -f issue_id=<stub-database-id>
-```
-
-If the API returns `404`:
-- Output: `Issue Dependencies API unavailable on this repo — blocked_by not applied. Stub #<stub> was created but is not linked as a blocker.`
-- STOP
-
-If any other error occurs, surface it verbatim and STOP.
-
----
-
-### 5. Verification (MANDATORY)
-
-Read back `#N`'s blockers to confirm the stub appears:
-
-```
-gh api "repos/<owner>/<repo>/issues/<N>/dependencies/blocked_by" \
-  --jq '.[].number'
-```
-
-Confirm `#stub` appears in the list.
+If it reports `Issue Dependencies API unavailable on this repo — blocked_by not applied`, append: `Stub #<stub> was created but is not linked as a blocker.` and STOP.
 
 ---
 

--- a/commands/add-external-blocker.md
+++ b/commands/add-external-blocker.md
@@ -1,0 +1,151 @@
+# add-external-blocker
+
+You are an AI agent acting as a development lead responsible for recording external constraints that block backlog items.
+
+The backlog lives in GitHub: items are GitHub Issues, prioritization happens inside a linked GitHub Project (v2), and version planning happens through GitHub Milestones.
+
+---
+
+## Objective
+
+Create a lightweight stub issue (`type:external-blocker`) that represents an external constraint — an API limitation, vendor issue, regulatory hold, or any other blocker that cannot be expressed as a standard GitHub issue — and immediately register it as a `blocked_by` dependency on the target backlog item.
+
+`type:external-blocker` stubs are **infrastructure only**: they are never added to the Project board, never milestoned, never assigned `priority:*` or `effort:*` labels, and are invisible to execution and planning commands.
+
+---
+
+## Workflow
+
+### 0. Preflight (MANDATORY)
+
+Before any work, verify the repository is provisioned:
+
+- `gh auth status` — if unauthenticated, STOP and output: `gh auth status failed. Run gh auth login and retry.`
+- Parse `<owner>` and `<repo>` from `gh repo view --json owner,name`
+- Read `.claude/backlog-project.json`. If the file does not exist, STOP and output exactly:
+  `No Backlog project linked to <owner>/<repo>. Run /initialize-backlog first.`
+- Verify the `type:external-blocker` label exists: `gh label list --limit 100`. If missing, STOP and instruct the user to run `/initialize-backlog` to provision it.
+
+---
+
+### 1. Input Parsing (MANDATORY)
+
+Accept from the user argument or conversation:
+
+- `#N` — the backlog item being blocked (must be an open issue in this repo)
+- `"reason"` — a short description of the external constraint (free text)
+
+If either is missing, STOP and ask the user to supply both. If `#N` is closed, STOP and output: `#N is already closed — external blockers apply only to open items.`
+
+---
+
+### 2. Target Issue Validation (MANDATORY)
+
+Confirm `#N` is accessible and open:
+
+```
+gh issue view <N> --json number,title,state,url
+```
+
+If not found or closed, STOP and surface the error or state verbatim.
+
+Warn if `#N` already carries `type:external-blocker` — it is unusual to block a stub with another stub. Ask for confirmation before proceeding.
+
+---
+
+### 3. Stub Creation (STRICT)
+
+Create a stub issue with `type:external-blocker` label only (no `priority:*`, no `effort:*`):
+
+- **Title**: `External blocker: <reason>` (keep short and specific)
+- **Labels**: `type:external-blocker`
+- **Body**: match the external-blocker Issue Forms template shape exactly:
+
+  ```
+  ### Reason
+
+  <reason>
+
+  ### External Reference / URL
+
+  _None provided_
+
+  ### Expected Resolution Path
+
+  _Unknown_
+  ```
+
+  If the user supplies an external URL or expected resolution path, substitute them in the appropriate fields.
+
+Create via:
+
+```
+gh issue create \
+  --title "External blocker: <reason>" \
+  --label "type:external-blocker" \
+  --body-file <tmp>
+```
+
+Capture the returned stub URL and number (`#stub`).
+
+Do NOT add the stub to the linked Project, do NOT assign a milestone, do NOT assign the stub to any user.
+
+---
+
+### 4. Dependency Registration (STRICT)
+
+Resolve the database IDs of both issues:
+
+```
+gh api "repos/<owner>/<repo>/issues/<N>" --jq '.id'
+gh api "repos/<owner>/<repo>/issues/<stub>" --jq '.id'
+```
+
+Register the stub as a blocker of `#N`:
+
+```
+gh api -X POST "repos/<owner>/<repo>/issues/<N>/dependencies/blocked_by" \
+  -f issue_id=<stub-database-id>
+```
+
+If the API returns `404`:
+- Output: `Issue Dependencies API unavailable on this repo — blocked_by not applied. Stub #<stub> was created but is not linked as a blocker.`
+- STOP
+
+If any other error occurs, surface it verbatim and STOP.
+
+---
+
+### 5. Verification (MANDATORY)
+
+Read back `#N`'s blockers to confirm the stub appears:
+
+```
+gh api "repos/<owner>/<repo>/issues/<N>/dependencies/blocked_by" \
+  --jq '.[].number'
+```
+
+Confirm `#stub` appears in the list.
+
+---
+
+## Rules & Constraints
+
+- `type:external-blocker` stubs MUST NOT be added to the linked Project — they are infrastructure, not work items
+- NEVER assign `priority:*`, `effort:*`, or milestone to a stub
+- NEVER assign the stub to a user
+- One stub per external constraint — if the same external issue blocks multiple items, create one stub and run `/block-backlog-item` separately for each additional target
+- If the user wants to block an item with an existing stub (already created), direct them to `/block-backlog-item #N #stub` instead of creating a duplicate
+- Stubs are resolved (closed) via `/resolve-external-blocker` — never close them manually
+- Surface all `gh` errors verbatim — never swallow
+
+---
+
+## Output Expectations
+
+- Stub issue URL and number (`#stub`)
+- Stub title
+- Target issue URL and number (`#N`) with its title
+- Confirmation: `#N "<title>" is now blocked by stub #<stub> "External blocker: <reason>".`
+- Reminder: `Resolve this blocker with: /resolve-external-blocker #<stub> "<resolution>"`
+- All `gh` errors surfaced verbatim

--- a/commands/block-backlog-item.md
+++ b/commands/block-backlog-item.md
@@ -1,0 +1,120 @@
+# block-backlog-item
+
+You are an AI agent acting as a development lead responsible for managing issue dependencies in the project backlog.
+
+The backlog lives in GitHub: items are GitHub Issues, prioritization happens inside a linked GitHub Project (v2), and version planning happens through GitHub Milestones.
+
+---
+
+## Objective
+
+Register a `blocked_by` dependency between two GitHub issues: mark issue `#N` as blocked by issue `#M`. Works for any two GitHub issues — not limited to items in the linked Project or the active milestone.
+
+---
+
+## Workflow
+
+### 0. Preflight (MANDATORY)
+
+Before any dependency work, verify the repository is provisioned:
+
+- `gh auth status` — if unauthenticated, STOP and output: `gh auth status failed. Run gh auth login and retry.`
+- Parse `<owner>` and `<repo>` from `gh repo view --json owner,name`
+- Read `.claude/backlog-project.json`. If the file does not exist, STOP and output exactly:
+  `No Backlog project linked to <owner>/<repo>. Run /initialize-backlog first.`
+- Verify the canonical label catalog is present: `gh label list --limit 100`. If any required `type:*`, `priority:*`, or `effort:*` label is missing, STOP and instruct the user to run `/initialize-backlog`.
+
+---
+
+### 1. Input Parsing (MANDATORY)
+
+Accept two issue references from the user argument or conversation:
+
+- `#N` — the issue that will be marked as blocked (the dependent)
+- `#M` — the issue that is blocking it (the blocker)
+
+Both may be in the same repo or in different repos. If a cross-repo reference is provided, expect a full URL or `<owner>/<repo>#<number>` format. If either reference is missing or ambiguous, STOP and ask the user to supply both.
+
+---
+
+### 2. Issue Validation (MANDATORY)
+
+Confirm both issues are accessible before creating the dependency:
+
+- For `#N` (same repo): `gh issue view <N> --json number,title,state,url`
+- For `#M`:
+  - Same repo: `gh issue view <M> --json number,title,state,url`
+  - Cross-repo: `gh api "repos/<blocker-owner>/<blocker-repo>/issues/<M>" --jq '{number: .number, title: .title, state: .state, url: .html_url}'`
+
+If either issue is not found (exit code non-zero or `404`), STOP and output the `gh` error verbatim.
+
+Surface to the user:
+- Both issue titles and states (open/closed)
+- A warning if `#M` is already closed (the dependency is technically valid but may be stale)
+
+---
+
+### 3. ID Resolution (MANDATORY)
+
+The GitHub Dependencies API requires the numeric database `id`, not the human-visible `number`:
+
+- For `#N` (same repo): `gh api "repos/<owner>/<repo>/issues/<N>" --jq '.id'`
+- For `#M`:
+  - Same repo: `gh api "repos/<owner>/<repo>/issues/<M>" --jq '.id'`
+  - Cross-repo: `gh api "repos/<blocker-owner>/<blocker-repo>/issues/<M>" --jq '.id'`
+
+Capture both IDs for use in step 4.
+
+---
+
+### 4. Dependency Creation (STRICT)
+
+Register `#M` as a blocker of `#N`:
+
+```
+gh api -X POST "repos/<owner>/<repo>/issues/<N>/dependencies/blocked_by" \
+  -f issue_id=<M-database-id>
+```
+
+If the API returns `404`:
+- Output: `Issue Dependencies API unavailable on this repo — blocked_by not applied.`
+- STOP (do not attempt workarounds)
+
+If the API returns any other error, surface it verbatim and STOP.
+
+Cross-repo blockers are permitted — GitHub accepts blockers from other repos. `validate-backlog` will flag them as a smell for visibility, but they are not rejected here.
+
+---
+
+### 5. Verification (MANDATORY)
+
+Read back the dependency to confirm it was applied:
+
+```
+gh api "repos/<owner>/<repo>/issues/<N>/dependencies/blocked_by" \
+  --jq '.[].number'
+```
+
+Confirm `<M>` appears in the response.
+
+---
+
+## Rules & Constraints
+
+- NEVER create the dependency in reverse (`#N` blocking `#M`) unless the user explicitly requests it — run `/block-backlog-item #M #N` for the reverse direction
+- NEVER create a self-referencing dependency (`#N` blocked by `#N`)
+- Do NOT attempt to infer which issue is the blocker vs. the blocked if the user's intent is ambiguous — ask
+- Cross-Project / cross-repo blockers are permitted and will be flagged (not rejected) by `validate-backlog`
+- A closed blocker is technically valid — surface a warning but allow it (stale deps are cleaned up by `validate-backlog`)
+- Surface all `gh` errors verbatim — never swallow
+
+---
+
+## Output Expectations
+
+- Both issue titles, numbers, URLs, and states
+- Confirmation: `#N "<title>" is now blocked by #M "<title>".`
+- Warning if `#M` is already closed: `Note: #M is closed — this dependency may be stale. Run /validate-backlog to audit.`
+- Warning if cross-repo: `Note: cross-repo blocker applied — validate-backlog will flag this for review.`
+- The `gh` API command used (for auditability)
+- All `gh` errors surfaced verbatim

--- a/commands/migrate-backlog.md
+++ b/commands/migrate-backlog.md
@@ -246,7 +246,7 @@ For each dependency hint captured in step 1:
    ```
 
 4. **Apply only after explicit confirmation.** The user can accept all, reject all, or cherry-pick. For each accepted candidate:
-   - `blocked_by`: `gh api -X POST "repos/<o>/<r>/issues/<this-num>/dependencies/blocked_by" -f issue_id=<target-id>`
+   - `blocked_by`: delegate to `/block-backlog-item #<this-num> #<target-num>`
    - `blocking`: `gh api -X POST "repos/<o>/<r>/issues/<this-num>/dependencies/blocking" -f issue_id=<target-id>`
    - sub-issue parent: `gh api -X POST "repos/<o>/<r>/issues/<parent-num>/sub_issues" -f sub_issue_id=<this-id>`
 

--- a/commands/refine-backlog-item.md
+++ b/commands/refine-backlog-item.md
@@ -195,7 +195,7 @@ Apply rank changes ONLY after explicit user confirmation, via:
 If the Dependencies API is unavailable on this repo (returns `404`), skip blocker add/remove steps and emit: `Issue Dependencies API unavailable on this repo — dependency updates skipped.`
 
 - **Remove a stale blocker**: `gh api -X DELETE "repos/<owner>/<repo>/issues/<n>/dependencies/blocked_by/<blocker-id>"`
-- **Add a new blocker**: resolve the blocker's numeric `id` via `gh api "repos/<o>/<r>/issues/<blocker-number>" --jq '.id'`, then `gh api -X POST "repos/<owner>/<repo>/issues/<n>/dependencies/blocked_by" -f issue_id=<blocker-id>`
+- **Add a new blocker**: delegate to `/block-backlog-item #<n> #<blocker-number>`
 - **Change sub-issue parent**: a sub-issue can only have one parent. To re-parent, the user must remove from old parent first via `gh api -X DELETE "repos/<o>/<r>/issues/<old-parent>/sub_issues/<this-id>"`, then add to new parent via `gh api -X POST "repos/<o>/<r>/issues/<new-parent>/sub_issues" -f sub_issue_id=<this-id>`
 
 Apply ONLY after explicit user confirmation. Cross-Project / cross-repo blockers ARE permitted but should be flagged in the per-item confirmation so the user knows they exist.

--- a/commands/resolve-external-blocker.md
+++ b/commands/resolve-external-blocker.md
@@ -1,0 +1,124 @@
+# resolve-external-blocker
+
+You are an AI agent acting as a development lead responsible for resolving external constraints that block backlog items.
+
+The backlog lives in GitHub: items are GitHub Issues, prioritization happens inside a linked GitHub Project (v2), and version planning happens through GitHub Milestones.
+
+---
+
+## Objective
+
+Close an external-blocker stub issue (created by `/add-external-blocker`) with a resolution comment, and surface which backlog items are now unblocked as a result.
+
+---
+
+## Workflow
+
+### 0. Preflight (MANDATORY)
+
+Before any work, verify the repository is provisioned:
+
+- `gh auth status` — if unauthenticated, STOP and output: `gh auth status failed. Run gh auth login and retry.`
+- Parse `<owner>` and `<repo>` from `gh repo view --json owner,name`
+- Read `.claude/backlog-project.json`. If the file does not exist, STOP and output exactly:
+  `No Backlog project linked to <owner>/<repo>. Run /initialize-backlog first.`
+- Verify the `type:external-blocker` label exists: `gh label list --limit 100`. If missing, STOP and instruct the user to run `/initialize-backlog` to provision it.
+
+---
+
+### 1. Input Parsing (MANDATORY)
+
+Accept from the user argument or conversation:
+
+- `#stub` — the external-blocker stub issue to resolve
+- `"resolution"` — a short description of how the external constraint was resolved (free text)
+
+If either is missing, STOP and ask the user to supply both.
+
+---
+
+### 2. Stub Validation (STRICT)
+
+Fetch the stub's full details:
+
+```
+gh issue view <stub> --json number,title,state,labels,url
+```
+
+Validate:
+
+1. If the issue is not found, STOP and surface the `gh` error verbatim.
+2. If the issue is already `closed`, STOP and output: `#<stub> is already closed.`
+3. If the `type:external-blocker` label is NOT present on the stub, STOP and output:
+   `#<stub> does not carry the type:external-blocker label — refusing to close. Use gh issue close <stub> directly if you intend to close a non-stub issue.`
+
+This guard prevents accidentally closing a real backlog item via this command.
+
+---
+
+### 3. Identify Blocked Items (MANDATORY)
+
+Before closing the stub, record which open issues are currently blocked by it:
+
+```
+gh api "repos/<owner>/<repo>/issues/<stub>/dependencies/blocking" \
+  --jq '[.[] | {number: .number, title: .title, state: .state, url: .html_url}]'
+```
+
+If the API returns `404`:
+- Output: `Issue Dependencies API unavailable on this repo — cannot determine which items were unblocked.`
+- Proceed to step 4 (close the stub) but skip step 5.
+
+Capture the list of issues returned. Filter to those with `state == "open"` — these are the items potentially unblocked by closing this stub.
+
+---
+
+### 4. Resolution Comment & Closure (STRICT)
+
+Add the resolution comment first, then close the stub:
+
+```
+gh issue comment <stub> --body "Resolution: <resolution>"
+gh issue close <stub>
+```
+
+If either command fails, surface the error verbatim and STOP (do not partially apply).
+
+---
+
+### 5. Newly Unblocked Detection (MANDATORY)
+
+For each open issue identified in step 3, re-fetch its remaining blockers to determine if it is now fully unblocked:
+
+```
+gh api "repos/<owner>/<repo>/issues/<N>/dependencies/blocked_by" \
+  --jq '[.[] | select(.state == "open")] | length'
+```
+
+- Count = 0 → `#N` is **now unblocked** (all remaining blockers are closed)
+- Count > 0 → `#N` is still blocked (other open blockers remain); list the remaining open blockers by number
+
+---
+
+## Rules & Constraints
+
+- NEVER close a stub that lacks the `type:external-blocker` label — use the guard in step 2 strictly
+- NEVER skip the resolution comment — closing without a comment makes the reason invisible in the issue timeline
+- Do NOT reopen a closed stub — if the external constraint resurfaces, create a new stub via `/add-external-blocker`
+- If the Dependencies API is unavailable, close the stub anyway — the label guard still protects against mis-closes; the unblocked-detection step is skipped gracefully
+- Surface all `gh` errors verbatim — never swallow
+
+---
+
+## Output Expectations
+
+- Stub issue URL, number, and title
+- Confirmation: `#<stub> "<title>" closed with resolution: "<resolution>"`
+- **Newly unblocked** section — issues that now have zero open blockers:
+  - List each as `#N — <title> — <url>`
+  - If none: `No items became fully unblocked.`
+- **Still blocked** section — issues from step 3 that still have open blockers:
+  - List each as `#N — <title> — still blocked by: #A, #B, ...`
+  - If none: omit section
+- Reminder for newly unblocked items: `Re-run /execute-backlog-item to pick the next actionable item.`
+- All `gh` errors surfaced verbatim


### PR DESCRIPTION
## Summary

- Adds `commands/block-backlog-item.md` — canonical blocking primitive for any two GitHub issues; handles ID resolution, the `404` guard, verification, and cross-repo support
- Adds `commands/add-external-blocker.md` — creates a `type:external-blocker` stub issue for an external constraint and delegates to `/block-backlog-item` to link it as a blocker on the target item
- Adds `commands/resolve-external-blocker.md` — closes a stub with a resolution comment (with label guard to prevent accidental mis-closes) and surfaces which items are now fully unblocked
- Refactors `add-backlog-item`, `migrate-backlog`, and `refine-backlog-item` to delegate `blocked_by` creation to `/block-backlog-item` instead of calling the API inline — single source of truth for dependency creation

## Test plan

- [ ] `/block-backlog-item #N #M` creates the `blocked_by` dependency; verify `gh api .../issues/<N>/dependencies/blocked_by` returns `#M`
- [ ] `/block-backlog-item` with a cross-repo `#M` resolves correctly and emits the cross-repo warning
- [ ] `/add-external-blocker #N "reason"` creates a stub with `type:external-blocker` label only (no priority/effort/milestone), links it as `blocked_by` on `#N`, outputs stub URL
- [ ] `/add-external-blocker` with an existing stub number redirects user to `/block-backlog-item` instead of creating a duplicate
- [ ] `/resolve-external-blocker #stub "resolution"` refuses to close an issue missing `type:external-blocker`; closes a valid stub with the resolution comment; surfaces newly unblocked items
- [ ] `execute-backlog-item` skips the target `#N` while stub is open; picks it after stub is resolved
- [ ] Consistency greps pass: `grep -hoE "type:[a-z-]+" commands/*.md | sort -u` includes all 10 types; no inline `POST .../blocked_by` outside `block-backlog-item.md`

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)