### PR TITLE
feat(external-blocker): filter type:external-blocker stubs from execution and planning commands

### DIFF
--- a/commands/execute-backlog-item.md
+++ b/commands/execute-backlog-item.md
@@ -39,6 +39,8 @@ Find the next item to execute by walking these tiers in order. Stop at the first
 
 Execution order is determined by the Project's rank — the topmost item in the `Todo` column wins. The `priority:*` label is severity classification ONLY and does NOT influence ordering.
 
+**Pre-filter (MANDATORY):** Before building the candidate lists for either tier, discard any issue whose labels include `type:external-blocker`. External-blocker stubs are infrastructure placeholders — they are never executable work items. Their titles surface in the "skipped because blocked" output when they are open blockers gating a real candidate (see step 2.5).
+
 #### Tier 1 — Active milestone, in Project, status Todo
 
 - Open issues assigned to the active milestone
@@ -83,7 +85,7 @@ For each candidate in rank order (Tier 1 first, then Tier 2):
 
 Outcomes:
 
-1. **A candidate wins** — proceed to step 2.6 (Sub-issue Check). In the eventual plan output, list every item that was skipped above this one with their open blockers, so the user knows why the queue was deeper than expected.
+1. **A candidate wins** — proceed to step 2.6 (Sub-issue Check). In the eventual plan output, list every item that was skipped above this one with their open blockers, so the user knows why the queue was deeper than expected. When a blocker carries `type:external-blocker`, show it as `External: <stub title>` rather than a plain issue reference.
 2. **Every candidate is blocked** — STOP. Report:
    - `All actionable items are blocked. Resolve a blocker or re-rank.`
    - Followed by a **per-blocker analysis table** with these columns:
@@ -287,7 +289,7 @@ Print:
 - Assignee (the authenticated user, assigned in step 5)
 - Final Project Status (typically `In Progress` until PR merges)
 - Whether the issue was assigned to the active milestone
-- Items skipped above this one because they were blocked (with `#N` and the open blockers that gated them) — surfaces why the picked item wasn't necessarily the topmost
+- Items skipped above this one because they were blocked (with `#N` and the open blockers that gated them; `type:external-blocker` blockers shown as `External: <stub title>`) — surfaces why the picked item wasn't necessarily the topmost
 - Parent items skipped because open sub-issues were found in the Project's Todo column (log: `Skipping parent #N — open sub-issues found. Picking #M.`)
 
 ---

--- a/commands/plan-release.md
+++ b/commands/plan-release.md
@@ -80,6 +80,7 @@ Ask the user which release mode to use:
 - Validate each resolved issue exists and is open:
   - `gh issue view <n> --json number,title,state,labels,milestone`
   - If an issue is closed or not found, surface the error and ask the user to correct the list.
+  - If any validated issue carries `type:external-blocker`, warn the user: "Issue #N is an external-blocker stub, not a work item. Stubs should not appear in release scope." Exclude the item unless the user explicitly overrides with a justification.
 - Display the confirmed issue list (number, title, type label, priority label, effort label) and ask for review.
 - Scan the scope for items that carry `type:feature` or any explicit breaking-change signal in `### What` / `### INVEST Notes` (read body via `gh issue view <n> --json body`). For each such item, WARN the user:
   > ⚠️ Issue #N "`<title>`" introduces new functionality / a breaking change, which is atypical for a maintenance release.
@@ -89,7 +90,7 @@ Ask the user which release mode to use:
 #### Mode B — Regular
 
 - Fetch unassigned candidates by intersecting:
-  - `gh issue list --state open --json number,title,labels,milestone,url --limit 200` — filter to items where `milestone == null`
+  - `gh issue list --state open --json number,title,labels,milestone,url --limit 200` — filter the result to items where `milestone == null` and whose labels do NOT include `type:external-blocker`
   - `gh project item-list <project-number> --owner <owner> --format json` — filter to Status = `Todo`
 - Present the candidate table in Project rank order:
 
@@ -102,12 +103,12 @@ Ask the user which release mode to use:
 
 #### Mode C — Automated
 
-- Fetch the same unassigned candidate set as Mode B.
+- Fetch the same unassigned candidate set as Mode B (same `type:external-blocker` exclusion applies).
 - For each candidate, check blockers:
   - `gh api "repos/<owner>/<repo>/issues/<n>/dependencies/blocked_by"` — collect open blockers. If the API returns `404`, treat all items as unblocked and note the unavailability.
   - Classify each blocked item:
     - **Resolvable within scope**: all open blockers are themselves in the candidate pool — the item CAN be included, but its blocker(s) MUST also be included and ranked above it.
-    - **Externally blocked**: at least one open blocker is outside the candidate pool (closed issue, different repo, or untracked) — exclude from the suggestion and note as "externally blocked".
+    - **Externally blocked**: at least one open blocker is outside the candidate pool (closed issue, different repo, or untracked) — exclude from the suggestion and note as "externally blocked". If the blocking issue carries `type:external-blocker`, show the stub's title as the blocking reason (e.g. `blocked by external constraint: Vendor API rate limit freeze`).
 - Analyze and group candidates by theme and cohesion:
   - Prefer P0/P1 items
   - Group by item type (e.g., a bug-fix release: `type:bug` + `type:security`; a feature release: `type:feature`)

--- a/commands/refine-backlog-item.md
+++ b/commands/refine-backlog-item.md
@@ -54,7 +54,7 @@ Bring the target issue to a fully refined state where:
 - Existing `### INVEST Notes` content — this is where `migrate-backlog` parks open questions
 - **Current relationships** (fetched via `gh api`):
   - If the Dependencies API returns `404` on this repo (private repo without paid plan), skip blocker/blocking fields and emit one warning: `Issue Dependencies API unavailable on this repo — dependency display and updates skipped.`
-  - Blockers (`blocked_by`): list each with `#N`, title, state. Cross-Project / cross-repo blockers explicitly flagged.
+  - Blockers (`blocked_by`): list each with `#N`, title, state. Cross-Project / cross-repo blockers explicitly flagged. If a blocker carries `type:external-blocker`, display it as `External: <stub title>` (e.g. `External: Vendor API rate limit freeze`) to distinguish it from regular issue dependencies.
     - `gh api "repos/<owner>/<repo>/issues/<n>/dependencies/blocked_by"`
   - Blocking: list each with `#N`, title, state.
     - `gh api "repos/<owner>/<repo>/issues/<n>/dependencies/blocking"`

--- a/commands/release-status.md
+++ b/commands/release-status.md
@@ -49,6 +49,8 @@ With the resolved milestone in hand, run these queries:
 1. **Issues assigned to the milestone**:
    `gh issue list --state all --milestone "<milestone-title>" --json number,title,labels,state,url --limit 500`
 
+   After fetching, **partition the results**: set aside any issue whose labels include `type:external-blocker` — these are infrastructure stubs and are **excluded from all milestone counts and metrics**. They are retained only to enrich the blocked-items table with stub titles as blocker context (step 3).
+
 2. **Project membership and Status**:
    `gh project item-list <project-number> --owner <owner> --format json`
    Build a lookup map: issue `number` → Project `Status` (`Todo` / `In Progress` / `Done`). Issues absent from the map are classified as "Not in Project."
@@ -85,7 +87,7 @@ Omit the `Due:` line if the milestone has no `due_on`.
 | 📋 Todo | N | N% |
 | ⚠️ Not in Project | N | — |
 
-- **% complete** = Done ÷ (all issues assigned to the milestone), rounded to the nearest integer.
+- **% complete** = Done ÷ (all non-stub issues assigned to the milestone), rounded to the nearest integer. `type:external-blocker` stubs are excluded from this denominator.
 - Omit the "Not in Project" row if its count is 0.
 
 #### Blocked Items
@@ -100,6 +102,8 @@ Otherwise:
 | Issue | Title | Blocked by |
 |-------|-------|------------|
 | [#N](\<url\>) | title | [#M](\<url\>), … |
+
+For blockers that carry `type:external-blocker`, replace the issue link with the stub's title in the "Blocked by" column (e.g. `External: Vendor API rate limit freeze`) to surface the external constraint clearly.
 
 #### Unestimated Items
 


### PR DESCRIPTION
## Summary

- `execute-backlog-item`: pre-filters `type:external-blocker` stubs from Todo candidates before ranking; stub titles surface as `External: <stub title>` in the "skipped because blocked" output
- `plan-release`: excludes stubs from Mode B/C scope candidates; Mode A warns if user provides a stub; Mode C shows stub title as blocking reason for externally-blocked items
- `release-status`: partitions stubs out of all milestone counts and metrics after fetch; stub titles appear as blocker context in the blocked-items table
- `refine-backlog-item`: displays stub blockers as `External: <stub title>` instead of a plain issue reference

`add-backlog-item` and `migrate-backlog` already referenced `type:external-blocker` from PR #55 — no changes needed.

## Test plan

- [ ] Run `/execute-backlog-item` in a repo where the topmost Todo item is a `type:external-blocker` stub — it must be skipped, never selected as a candidate
- [ ] Run `/execute-backlog-item` on an item blocked by a stub — verify the stub appears as `External: <stub title>` in the skipped list
- [ ] Run `/plan-release` Mode B — verify stubs are absent from the candidate table
- [ ] Run `/plan-release` Mode C — verify externally-blocked items show stub title as blocking reason
- [ ] Run `/release-status` on a milestone containing a stub — verify stub is excluded from all counts and % complete
- [ ] Run `/refine-backlog-item` on an item blocked by a stub — verify it renders as `External: <stub title>`

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)