### PR TITLE
feat(validate-backlog): add D. External Dependencies section for cross-repo blockers

### DIFF
--- a/commands/validate-backlog.md
+++ b/commands/validate-backlog.md
@@ -237,6 +237,17 @@ Flag each of the following as a Quality or Consistency issue:
 
 > **Note on closed blockers:** GitHub does not remove `blocked_by` dependencies when a blocker is closed — the link persists for historical tracking and regression detection. A closed blocker is therefore **not** flagged as stale or inconsistent. `execute-backlog-item` already treats closed blockers as satisfied; `validate-backlog` does the same.
 
+#### Cross-repo blocker collection
+
+While walking `blocked_by` for each Project item, collect entries where the blocker URL references a different owner or repo than the current repo. For each cross-repo blocker:
+
+- Record: blocked item `#N`, external repo (`<owner>/<repo>`), blocker issue number and title, blocker state
+- Fetch blocker state: `gh api "repos/<blocker-owner>/<blocker-repo>/issues/<blocker-number>" --jq '.state'`
+- **Include only open cross-repo blockers** — closed ones are satisfied by design (same rule as same-repo closed blockers) and require no action
+- If no open cross-repo blockers are found, the "D. External Dependencies" section is omitted entirely
+
+This collection pass uses data already fetched from `blocked_by` — no additional API calls beyond the per-blocker state lookups.
+
 #### Stub-specific dependency checks
 
 For each `type:external-blocker` stub in the Project:
@@ -312,7 +323,24 @@ Produce a **Validation Report** with:
 - Sub-issue parents not in the linked Project
 - Sub-issue milestone divergence (informational)
 
-### D. Recommendations
+### D. External Dependencies
+
+Consolidates all open cross-repo blockers into one view. Only open blockers are shown — closed cross-repo blockers are satisfied by design and require no action.
+
+If the Dependencies API returned `404` on this repo, replace this section with a single line:
+`Issue Dependencies API unavailable — external dependency audit skipped.`
+
+If no open cross-repo blockers exist, **omit this section entirely**.
+
+Otherwise, render a summary table:
+
+| Blocked item  | External repo | Blocker       | State |
+|---------------|---------------|---------------|-------|
+| #N — title    | owner/repo    | #M — title    | open  |
+
+Follow the table with a suggested action per row: `Coordinate with owning team (owner/repo) to resolve #M before #N can proceed.`
+
+### E. Recommendations
 
 - Suggested fixes (with `gh issue edit <n> --add-label ...` snippets the user can run)
 - Items to split / merge


### PR DESCRIPTION
## Summary

- Adds **D. External Dependencies** section to `/validate-backlog` that consolidates all open cross-repo blockers into a single table view
- Section is omitted entirely when no open cross-repo blockers exist; replaced with a warning when the Dependencies API returns 404
- Closed cross-repo blockers are excluded — they are satisfied by design and retained as GitHub historical reference (same invariant already applied to same-repo closed blockers)
- Renames old **D. Recommendations** → **E. Recommendations**

## Acceptance Criteria

- [x] `/validate-backlog` queries `blocked_by` for all Project items and filters for cross-repo results
- [x] "D. External Dependencies" section shows: blocked item #N, external repo, blocker #M title, blocker state
- [x] Closed cross-repo blockers excluded (not flagged, no DELETE snippets — closed deps are historical reference)
- [x] Section is omitted entirely if no open cross-repo blockers exist
- [x] Dependencies API 404 is handled gracefully: section is replaced with a warning message

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)