### PR TITLE
fix(validate-backlog): add stubs to Project so stub audit checks fire

### DIFF
--- a/commands/add-external-blocker.md
+++ b/commands/add-external-blocker.md
@@ -10,7 +10,7 @@ The backlog lives in GitHub: items are GitHub Issues, prioritization happens ins
 
 Create a lightweight stub issue (`type:external-blocker`) that represents an external constraint — an API limitation, vendor issue, regulatory hold, or any other blocker that cannot be expressed as a standard GitHub issue — and immediately register it as a `blocked_by` dependency on the target backlog item.
 
-`type:external-blocker` stubs are **infrastructure only**: they are never added to the Project board, never milestoned, never assigned `priority:*` or `effort:*` labels, and are invisible to execution and planning commands.
+`type:external-blocker` stubs are **infrastructure only**: they are added to the Project board with Status=`Todo` so they can be tracked and have their health audited, but never milestoned, never assigned `priority:*` or `effort:*` labels, and skipped by execution and planning commands.
 
 ---
 
@@ -88,7 +88,25 @@ gh issue create \
 
 Capture the returned stub URL and number (`#stub`).
 
-Do NOT add the stub to the linked Project, do NOT assign a milestone, do NOT assign the stub to any user.
+Do NOT assign a milestone, do NOT assign the stub to any user.
+
+Add the stub to the linked Project and set its Status to `Todo`:
+
+```
+gh project item-add <project-number> --owner <owner> --url <stub-url>
+```
+
+Resolve the new item's ID, then set Status:
+
+```
+gh project item-edit \
+  --id <item-id> \
+  --project-id <project-id> \
+  --field-id <status-field-id> \
+  --single-select-option-id <todo-option-id>
+```
+
+Use the `project_id`, `project_number`, and `status_field_id` / `status_options.Todo` values already loaded from `.claude/backlog-project.json`.
 
 ---
 
@@ -107,7 +125,7 @@ If it reports `Issue Dependencies API unavailable on this repo — blocked_by no
 
 ## Rules & Constraints
 
-- `type:external-blocker` stubs MUST NOT be added to the linked Project — they are infrastructure, not work items
+- `type:external-blocker` stubs MUST be added to the linked Project with Status=`Todo` — this makes them visible to `validate-backlog` for health auditing and project tracking
 - NEVER assign `priority:*`, `effort:*`, or milestone to a stub
 - NEVER assign the stub to a user
 - One stub per external constraint — if the same external issue blocks multiple items, create one stub and run `/block-backlog-item` separately for each additional target

--- a/commands/resolve-external-blocker.md
+++ b/commands/resolve-external-blocker.md
@@ -73,7 +73,7 @@ Capture the list of issues returned. Filter to those with `state == "open"` — 
 
 ---
 
-### 4. Resolution Comment & Closure (STRICT)
+### 4. Resolution Comment, Closure & Project Status (STRICT)
 
 Add the resolution comment first, then close the stub:
 
@@ -83,6 +83,18 @@ gh issue close <stub>
 ```
 
 If either command fails, surface the error verbatim and STOP (do not partially apply).
+
+After closing, set the stub's Project Status to `Done`:
+
+```
+gh project item-edit \
+  --id <item-id> \
+  --project-id <project-id> \
+  --field-id <status-field-id> \
+  --single-select-option-id <done-option-id>
+```
+
+Resolve `<item-id>` via `gh project item-list <project-number> --owner <owner> --format json` if not already known. Use `project_id`, `project_number`, `status_field_id`, and `status_options.Done` from `.claude/backlog-project.json`. If the Project Status update fails (e.g. the stub was never added to the Project), surface the error as a warning but do not abort — the stub is already closed.
 
 ---
 


### PR DESCRIPTION
## Summary

- `type:external-blocker` stubs are now added to the Project with Status=`Todo` on creation (`add-external-blocker`) and set to `Done` on resolution (`resolve-external-blocker`)
- This makes `validate-backlog`'s existing §2a Reason-field check and §8.5 orphaned-stub check fire naturally — they were permanently unreachable dead code because stubs were never Project items
- Closed stubs retain their `blocked_by` links by design (same as regular closed blockers) — no behavior change there

## Test plan

- [ ] Run `/add-external-blocker` on a scratch repo — verify stub appears in Project with Status=Todo
- [ ] Run `/validate-backlog` with a stub that has an empty Reason field — verify it surfaces as a Quality issue (AC 8)
- [ ] Run `/validate-backlog` with an open stub blocking no issues — verify it surfaces as a Quality issue (AC 9)
- [ ] Run `/resolve-external-blocker` on a stub — verify Project Status flips to Done
- [ ] Run consistency greps from CLAUDE.md — all pass

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)