### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
         "source": "github",
         "repo": "gringolito/github-backlog-management-skill"
       },
-      "version": "0.1.0",
+      "version": "0.2.0",
       "category": "productivity"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "github-backlog-management",
   "description": "GitHub-native backlog automation. Manage Issues + Projects v2 with AI-enforced INVEST quality, dependency tracking, and one-command execution.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Filipe Utzig",
     "email": "filipe@gringolito.com"


### PR DESCRIPTION
Release prep for v0.2.0. Milestone: https://github.com/gringolito/github-backlog-management-skill/milestone/2.

- Bump `.claude-plugin/plugin.json` version: 0.1.0 → 0.2.0
- Bump `.claude-plugin/marketplace.json` version: 0.1.0 → 0.2.0