### PR TITLE
chore: add external-blocker issue forms template

### DIFF
--- a/.github/ISSUE_TEMPLATE/external-blocker.yml
+++ b/.github/ISSUE_TEMPLATE/external-blocker.yml
@@ -1,0 +1,29 @@
+name: External Blocker
+description: Record an external constraint (API limitation, vendor issue, regulatory hold, etc.) blocking a backlog item
+title: "External blocker: "
+labels: ["type:external-blocker"]
+body:
+  - type: textarea
+    id: reason
+    attributes:
+      label: Reason
+      description: What external constraint is causing the block?
+      placeholder: e.g. "Vendor API does not support X; waiting for SDK v3 release"
+    validations:
+      required: true
+  - type: input
+    id: external-reference
+    attributes:
+      label: External Reference / URL
+      description: Link to vendor issue, RFC, ticket, or documentation (optional).
+      placeholder: https://...
+    validations:
+      required: false
+  - type: textarea
+    id: resolution-path
+    attributes:
+      label: Expected Resolution Path
+      description: How is this expected to be resolved? (optional)
+      placeholder: e.g. "Monitor vendor release notes; re-evaluate in next sprint"
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/external-blocker.yml` — the canonical Issue Forms template for infrastructure stub issues created by `/add-external-blocker`
- Pre-applies the `type:external-blocker` label on creation
- No "Blocked Item" field — a single stub can block multiple items; GitHub tracks blocking relationships natively via the Issue Dependencies API

## Notes

- `backlog-item.yml` was already merged (PR #1) and is unchanged
- `validate-backlog` does not parse `external-blocker.yml` sections (only `backlog-item.yml` sections are parsed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)