### PR TITLE
fix: remove empty title field from backlog-item issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/backlog-item.yml
+++ b/.github/ISSUE_TEMPLATE/backlog-item.yml
@@ -1,6 +1,5 @@
 name: Backlog Item
 description: Add a new item to the project backlog
-title: ""
 labels: []
 body:
   - type: textarea

--- a/commands/initialize-backlog.md
+++ b/commands/initialize-backlog.md
@@ -157,7 +157,6 @@ The remaining provisioning steps (project, labels) are NOT gated by this PR — 
 ```yaml
 name: Backlog Item
 description: Add a new item to the project backlog
-title: ""
 labels: []
 body:
   - type: textarea


### PR DESCRIPTION
## Summary

- Removes the `title: ""` field from `.github/ISSUE_TEMPLATE/backlog-item.yml` (installed template)
- Removes the same field from the canonical template YAML in `commands/initialize-backlog.md` (prevents re-introduction on future `/initialize-backlog` runs)

GitHub Issue Forms schema requires `title` to be a non-empty string if present; an empty string fails validation and breaks issue creation via the GitHub web UI.

## Acceptance Criteria

- [x] The `backlog-item.yml` template no longer includes a `title` field
- [x] Future `/initialize-backlog` runs will not re-introduce the broken field

## Test plan

- [ ] Verify `.github/ISSUE_TEMPLATE/backlog-item.yml` no longer contains a `title` key
- [ ] Open a new issue via GitHub web UI using the Backlog Item template — confirm no validation error appears

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)