### PR TITLE
feat: promote SKILL.md to skills/github-backlog-management/SKILL.md as router skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,6 @@ Add the marketplace and install the plugin with two Claude Code commands:
 
 Restart Claude Code if it was already running. All commands below are then available in any repository you open with Claude Code.
 
-### Manual install (fallback)
-
-If your version of Claude Code does not support the plugin system, clone directly into the skills directory:
-
-```bash
-git clone https://github.com/gringolito/github-backlog-management-skill.git ~/.claude/skills/github-backlog-management
-```
-
-Restart Claude Code if it was already running.
-
 ---
 
 ## Authentication & Permissions

--- a/skills/github-backlog-management/SKILL.md
+++ b/skills/github-backlog-management/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: github-backlog-management
-description: GitHub-native backlog automation. Manage Issues + Projects v2 with AI-enforced INVEST quality, dependency tracking, and one-command execution. Create or import backlog items, prioritize work, execute tasks, audit quality, or bootstrap a workflow from scratch.
+description: Manage backlog, issues, and milestones with INVEST quality enforcement. Use for requests about backlog, issue, milestone, prioritize, INVEST, refine, audit, or clarify.
 ---
 
 # GitHub Backlog Management
-
-## Overview
 
 A set of slash commands for a fully GitHub-native backlog workflow — Issues, Projects v2, Milestones, and Labels. No external tools, no database, no webhooks.
 
@@ -36,6 +34,19 @@ initialize-backlog ─► plan-release ─► add-backlog-item / migrate-backlog
 
 `initialize-backlog` is the bootstrap. Every other command preflights for a linked Project and stops with a standard error if missing.
 
+## INVEST Quality Bar
+
+Every item must pass before entering the queue:
+
+| Letter | Criterion | What to check |
+|--------|-----------|---------------|
+| **I** | Independent | Buildable without waiting on another in-flight item |
+| **N** | Negotiable | The *what* is agreed; the *how* is open |
+| **V** | Valuable | Delivers something real to a user or the system |
+| **E** | Estimable | Team can roughly size it |
+| **S** | Small | Fits inside a single cycle of work |
+| **T** | Testable | Has acceptance criteria concrete enough to verify |
+
 ## Key Invariants (apply to all commands)
 
 **Label catalog**
@@ -48,6 +59,8 @@ initialize-backlog ─► plan-release ─► add-backlog-item / migrate-backlog
 `### What` · `### Why` · `### In Scope` · `### Out of Scope` · `### Acceptance Criteria` · `### INVEST Notes`
 
 **Metadata file**: `.claude/backlog-project.json` — written by `initialize-backlog`, read directly by all other commands.
+
+**Standard preflight stop string**: `No Backlog project linked to <owner>/<repo>. Run /initialize-backlog first.`
 
 **Priority vs rank**: `priority:*` is severity classification. Project rank (topmost Todo item) is execution order. They should stay consistent but are independent concepts — `execute-backlog-item` sorts by rank only.
 


### PR DESCRIPTION
## Summary

- Moves `SKILL.md` from repo root to `skills/github-backlog-management/SKILL.md` so the plugin system registers the skill and Claude can route on vague backlog prompts (e.g. "clean up our backlog")
- Tightens frontmatter `description` to include all required trigger verbs: *backlog*, *issue*, *milestone*, *prioritize*, *INVEST*, *refine*, *audit*, *clarify*
- Adds INVEST quality table and standard preflight stop string to the skill content; trims to 69 lines (≤ 110 AC)
- Removes the "Manual install (fallback)" section from `README.md`

Closes #30

## AC Coverage

- [x] `skills/github-backlog-management/SKILL.md` exists and is ≤ 110 lines (69 lines)
- [x] Frontmatter `name` matches plugin name; `description` includes all trigger verbs
- [x] Repo-root `SKILL.md` removed
- [x] `README.md` has no "Manual install" section
- [ ] Scratch-repo smoke test (AC5 + AC6) — requires live plugin install; manual verification needed after merge

## Test plan

- [ ] Verify `skills/github-backlog-management/SKILL.md` exists with correct frontmatter
- [ ] Confirm root `SKILL.md` is gone
- [ ] Confirm README has no "Manual install" section
- [ ] Manual: install plugin in a scratch repo and verify Claude routes a vague backlog prompt to one of the `/commands`

🤖 Generated with [Claude Code](https://claude.com/claude-code)