### PR TITLE
chore: tighten plugin manifest — $schema, keywords, drop redundant commands field

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,8 @@
         "repo": "gringolito/github-backlog-management-skill"
       },
       "version": "0.2.0",
-      "category": "productivity"
+      "category": "productivity",
+      "keywords": ["github", "backlog", "issues", "projects-v2", "milestones", "labels", "invest", "agile", "prioritization"]
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,5 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "gringolito",
-  "description": "Plugins by Filipe Utzig",
   "owner": {
     "name": "Filipe Utzig",
     "email": "filipe@gringolito.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "github-backlog-management",
   "description": "GitHub-native backlog automation. Manage Issues + Projects v2 with AI-enforced INVEST quality, dependency tracking, and one-command execution.",
   "version": "0.2.0",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "github-backlog-management",
   "description": "GitHub-native backlog automation. Manage Issues + Projects v2 with AI-enforced INVEST quality, dependency tracking, and one-command execution.",
   "version": "0.2.0",
@@ -9,5 +10,5 @@
   "homepage": "https://github.com/gringolito/github-backlog-management-skill",
   "repository": "https://github.com/gringolito/github-backlog-management-skill",
   "license": "MIT",
-  "commands": "./commands"
+  "keywords": ["github", "backlog", "issues", "projects-v2", "milestones", "labels", "invest", "agile", "prioritization"]
 }

--- a/commands/add-backlog-item.md
+++ b/commands/add-backlog-item.md
@@ -1,3 +1,7 @@
+---
+description: Add a new backlog item to the GitHub Project with INVEST validation, labels, and optional dependencies.
+---
+
 # add-backlog-item
 
 You are an AI agent acting as a Senior Project Manager responsible for maintaining the project backlog.

--- a/commands/add-external-blocker.md
+++ b/commands/add-external-blocker.md
@@ -1,3 +1,7 @@
+---
+description: Record an external constraint as a stub issue that blocks a backlog item.
+---
+
 # add-external-blocker
 
 You are an AI agent acting as a development lead responsible for recording external constraints that block backlog items.

--- a/commands/block-backlog-item.md
+++ b/commands/block-backlog-item.md
@@ -1,3 +1,7 @@
+---
+description: Set a blocked_by dependency between a backlog item and its blocker issue.
+---
+
 # block-backlog-item
 
 You are an AI agent acting as a development lead responsible for managing issue dependencies in the project backlog.

--- a/commands/close-release.md
+++ b/commands/close-release.md
@@ -1,3 +1,7 @@
+---
+description: "Orchestrate milestone closure: audit completion, cut the release tag, and archive the milestone."
+---
+
 # close-release
 
 You are an AI agent acting as a release manager responsible for orchestrating a structured milestone closure ceremony.

--- a/commands/execute-backlog-item.md
+++ b/commands/execute-backlog-item.md
@@ -1,3 +1,7 @@
+---
+description: Pick and execute the highest-priority unblocked backlog item in the active milestone.
+---
+
 # execute-backlog-item
 
 You are an AI agent acting as a development lead responsible for executing backlog items.

--- a/commands/initialize-backlog.md
+++ b/commands/initialize-backlog.md
@@ -1,3 +1,7 @@
+---
+description: "Bootstrap the GitHub-native backlog system: create the Project, labels, and Issue Forms template PR."
+---
+
 # initialize-backlog
 
 You are an AI agent acting as a Senior Project Manager responsible for bootstrapping the GitHub-native backlog system for this repository.

--- a/commands/migrate-backlog.md
+++ b/commands/migrate-backlog.md
@@ -1,3 +1,7 @@
+---
+description: Migrate items from a BACKLOG.md into GitHub Issues with label normalization and dependency inference.
+---
+
 # migrate-backlog
 
 You are an AI agent acting as a Senior Project Manager responsible for migrating, normalizing, and validating backlog items into GitHub.

--- a/commands/plan-release.md
+++ b/commands/plan-release.md
@@ -1,3 +1,7 @@
+---
+description: Plan a new release by creating a GitHub Milestone with goals, scope, and due date.
+---
+
 # plan-release
 
 You are an AI agent acting as a Senior Project Manager responsible for planning the next release.

--- a/commands/refine-backlog-item.md
+++ b/commands/refine-backlog-item.md
@@ -1,3 +1,7 @@
+---
+description: Refine a single ambiguous backlog item through guided INVEST validation and label correction.
+---
+
 # refine-backlog-item
 
 You are an AI agent acting as a Senior Project Manager refining a single ambiguous backlog item.

--- a/commands/refine-backlog.md
+++ b/commands/refine-backlog.md
@@ -1,3 +1,7 @@
+---
+description: Orchestrate a refinement session over all backlog items flagged needs-clarification or missing metadata.
+---
+
 # refine-backlog
 
 You are an AI agent acting as a Senior Project Manager orchestrating a backlog refinement session. You identify all items needing clarification or carrying incomplete metadata, present them to the user for selection, and drive the refinement loop — delegating each item to `/refine-backlog-item` and checking in between iterations whether to continue.

--- a/commands/release-status.md
+++ b/commands/release-status.md
@@ -1,3 +1,7 @@
+---
+description: Display a real-time health dashboard for the active or specified GitHub Milestone.
+---
+
 # release-status
 
 You are an AI agent acting as a release manager responsible for producing a real-time health dashboard for a GitHub Milestone.

--- a/commands/resolve-external-blocker.md
+++ b/commands/resolve-external-blocker.md
@@ -1,3 +1,7 @@
+---
+description: Resolve an external blocker stub and clear the dependency to unblock waiting backlog items.
+---
+
 # resolve-external-blocker
 
 You are an AI agent acting as a development lead responsible for resolving external constraints that block backlog items.

--- a/commands/validate-backlog.md
+++ b/commands/validate-backlog.md
@@ -1,3 +1,7 @@
+---
+description: Audit backlog quality, INVEST compliance, and label consistency without mutating any issues.
+---
+
 # validate-backlog
 
 You are an AI agent acting as a Senior Project Manager responsible for validating the quality, consistency, and integrity of the project backlog.


### PR DESCRIPTION
## Summary

- Remove `"commands": "./commands"` from `plugin.json` — default scan path, redundant
- Add `keywords` array to both `plugin.json` and `marketplace.json` for marketplace discoverability
- Remove `$schema` from `plugin.json` and `$schema` + root `description` from `marketplace.json` — all rejected by `claude plugin validate` as unrecognized keys
- Add YAML frontmatter `description` to all 13 command files — fixes plugin validate warnings

Both manifests now pass `claude plugin validate` with no errors.

## Acceptance Criteria coverage

- [x] `plugin.json` no longer contains the `"commands"` field
- [x] `plugin.json` contains a `"keywords"` array with the 9 specified terms
- [x] `marketplace.json` plugin entry contains the same `"keywords"` array
- [x] `claude plugin validate` passes against both files (no errors)
- [x] All 13 command files have frontmatter descriptions (no more validate warnings)
- [ ] Loading the plugin in a scratch repo still discovers all commands

## Notes

The `$schema` field proposed in the original AC is not supported by `claude plugin validate` — it is rejected as an unrecognized key in `plugin.json`. The field was added then removed after running the validator. Similarly, the pre-existing `$schema` and root-level `description` in `marketplace.json` were also rejected and removed.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)