### PR TITLE
chore: add CI workflow to validate plugin manifest on every PR

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,7 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "gringolito",
+  "description": "Plugins by Filipe Utzig",
   "owner": {
     "name": "Filipe Utzig",
     "email": "filipe@gringolito.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "github-backlog-management",
   "description": "GitHub-native backlog automation. Manage Issues + Projects v2 with AI-enforced INVEST quality, dependency tracking, and one-command execution.",
   "version": "0.2.0",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,9 @@ jobs:
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code
 
+      - name: Check Claude Code installed version
+        run: claude --version
+
       - name: Validate marketplace manifest
         run: claude plugin validate .claude-plugin/marketplace.json
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  validate-plugin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Validate marketplace manifest
+        run: claude plugin validate .claude-plugin/marketplace.json
+
+      - name: Validate plugin manifest
+        run: claude plugin validate .claude-plugin/plugin.json


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yaml` that installs Claude Code and runs `claude plugin validate` against both `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`
- Triggers on every pull request (any branch) and on push to `master`
- Uses `permissions: contents: read` (least-privilege — checkout only, no write access needed)
- Adds `$schema` to both manifests for IDE validation support
- Adds `description` to `marketplace.json` (resolves `claude plugin validate` warning about missing marketplace description)

## Acceptance Criteria

- [x] `.github/workflows/ci.yaml` exists and runs on `pull_request` and `push` to `master`
- [x] Least privilege principle applied (`permissions: contents: read`)
- [x] Workflow installs Claude Code (`npm install -g @anthropic-ai/claude-code`) and runs `claude plugin validate`
- [x] A deliberately broken `plugin.json` causes the workflow to fail — verify by temporarily removing a required field (e.g. `name`) and pushing; `claude plugin validate` exits non-zero
- [x] A clean repo passes the workflow — both manifests currently pass locally
- [x] `marketplace.json` validation included and exercisable — verify by introducing a JSON syntax error in the file

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)