### PR TITLE
feat: add /backlog-health command — strategic portfolio health report

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,11 +15,12 @@ initialize-backlog   ─►  plan-release   ─►  add-backlog-item / migrate-b
                                                   │
                                                   ├─►  refine-backlog ─► refine-backlog-item   (needs-clarification)
                                                   ├─►  release-status                          (read-only dashboard)
+                                                  ├─►  backlog-health                          (read-only portfolio report)
                                                   ├─►  validate-backlog                        (read-only audit)
                                                   └─►  execute-backlog-item                    (picks topmost unblocked)
 ```
 
-`initialize-backlog` is the bootstrap. Every other command preflights for a Project linked to the repo and stops with the standard error if missing. `plan-release` creates Milestones (releases). `add-backlog-item` and `migrate-backlog` create Issues. `execute-backlog-item` picks work. `refine-backlog` orchestrates a session over items flagged `needs-clarification`, delegating each to `refine-backlog-item`. `release-status` produces a read-only milestone health dashboard. `validate-backlog` audits without mutating.
+`initialize-backlog` is the bootstrap. Every other command preflights for a Project linked to the repo and stops with the standard error if missing. `plan-release` creates Milestones (releases). `add-backlog-item` and `migrate-backlog` create Issues. `execute-backlog-item` picks work. `refine-backlog` orchestrates a session over items flagged `needs-clarification`, delegating each to `refine-backlog-item`. `release-status` produces a read-only milestone health dashboard. `backlog-health` produces a read-only strategic portfolio health report (distribution, age cohorts, overdue P0/P1, stale In-Progress, metadata debt). `validate-backlog` audits without mutating.
 
 ## Invariants that MUST be preserved across all commands
 
@@ -29,7 +30,7 @@ When editing any command, these must stay consistent across files. Most consiste
 grep -hoE "type:[a-z-]+" commands/*.md | sort -u           # 10 type labels
 grep -hoE "priority:P[0-3]" commands/*.md | sort -u         # 4 priority labels
 grep -hoE "effort:(XS|S|M|L|XL)\b" commands/*.md | sort -u  # 5 effort labels
-grep -n "No Backlog project linked" commands/*.md           # identical preflight stop string in 8 files
+grep -n "No Backlog project linked" commands/*.md           # identical preflight stop string in all consumer commands
 grep -n ".claude/backlog-project.json" commands/*.md        # metadata file referenced everywhere
 ```
 
@@ -79,4 +80,5 @@ There is no automated test suite. The end-to-end smoke is:
 5. `/execute-backlog-item` → picks topmost unblocked item, surfaces skipped-because-blocked items above it.
 6. `/release-status` → confirm Markdown dashboard renders with correct counts by Status, blocked-items section (or graceful omission on `404`), and unestimated list; run again with an explicit milestone argument and verify it resolves correctly.
 7. `/validate-backlog` → seed deliberate violations (missing `priority:*`, dangling blocker, cross-Project blocker) and confirm they appear in the Critical/Quality/Consistency report sections.
-8. `/refine-backlog` → presents the `needs-clarification` queue, user selects items, loop delegates to `/refine-backlog-item`; label removed only after pre-removal validation gate passes.
+8. `/backlog-health` → confirm Markdown report renders all six sections (summary, distribution tables, age cohorts, overdue P0/P1, stale In-Progress, metadata debt); verify stubs excluded from counts; confirm zero mutations.
+9. `/refine-backlog` → presents the `needs-clarification` queue, user selects items, loop delegates to `/refine-backlog-item`; label removed only after pre-removal validation gate passes.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Add one of the blocks below to `.claude/settings.json` in any repo where you use
 | `/refine-backlog` | Lists all `needs-clarification` candidates, lets you select which to refine, then loops through them one by one — asking continue/stop after each. |
 | `/refine-backlog-item` | Refines a single `needs-clarification` item: discovery dialogue, body rewrite, INVEST gate, label/rank/dep re-evaluation, and label removal after a final validation pass. |
 | `/release-status` | Read-only milestone health dashboard — issue counts by Project Status, % complete, blocked items, and unestimated items. Accepts an optional milestone argument; defaults to the active milestone. |
+| `/backlog-health` | Read-only strategic portfolio health report — open-issue distribution by type, priority, and effort; age cohorts; overdue P0/P1 items; stale In-Progress items; metadata debt. Suitable for leadership updates and retrospectives. |
 | `/validate-backlog` | Read-only audit. Emits actionable `gh issue edit ...` snippets. Never mutates anything. |
 | `/execute-backlog-item` | Picks the topmost unblocked Todo item, respects active milestone scope, skips blocked items, and walks you through to a PR. |
 
@@ -260,6 +261,14 @@ Produces a Markdown dashboard for the active milestone: issue counts by Project 
 ```
 
 The output is valid GitHub-Flavored Markdown — paste it directly into a standup document, Slack message, or GitHub comment.
+
+### Checking portfolio health
+
+```
+/backlog-health
+```
+
+Produces a Markdown strategic health report across all open Project issues: distribution tables by type, priority, and effort; age cohorts (<7d, 7–30d, 30–90d, >90d); overdue P0 (>14 days) and P1 (>30 days) items; stale In-Progress items (no update in 7+ days); and a metadata debt list of issues missing any label group. Useful for weekly leadership updates or retrospectives.
 
 ### Auditing backlog health
 

--- a/commands/backlog-health.md
+++ b/commands/backlog-health.md
@@ -1,0 +1,209 @@
+---
+description: Produce a read-only strategic portfolio health report across all open issues in the linked Project.
+---
+
+# backlog-health
+
+You are an AI agent acting as a backlog analyst responsible for producing a strategic portfolio health report across all open issues in the linked GitHub Project.
+
+The backlog lives in GitHub: items are GitHub Issues, prioritization happens inside a linked GitHub Project (v2), and version planning happens through GitHub Milestones.
+
+This command is **read-only** — it never mutates issues, labels, projects, or milestones.
+
+---
+
+## Objective
+
+Produce a Markdown strategic portfolio health report covering: open-issue distribution by type, priority, and effort; age cohorts; overdue high-priority items; stale In-Progress items; and metadata debt (items missing label coverage). The report is suitable for weekly leadership updates, retrospectives, or health checks.
+
+---
+
+## Workflow
+
+### 0. Preflight (MANDATORY)
+
+Before any work, verify the repository is provisioned:
+
+- Read `.claude/backlog-project.json`. If the file does not exist, STOP and output exactly:
+  `No Backlog project linked to <owner>/<repo>. Run /initialize-backlog first.`
+- Verify the canonical label catalog is present (`type:*`, `priority:*`, `effort:*`):
+  - `gh label list --limit 100`
+  - If any required label group is missing, STOP and instruct the user to run `/initialize-backlog` to provision them
+
+---
+
+### 1. Data Collection (MANDATORY)
+
+Run these two queries:
+
+1. **All open issues**:
+   `gh issue list --state open --json number,title,labels,assignees,createdAt,updatedAt,url --limit 200`
+
+   After fetching, **pre-filter**: discard any issue whose labels include `type:external-blocker` — these are infrastructure stubs, never work items, and are excluded from all counts and metrics.
+
+2. **Project membership and Status**:
+   `gh project item-list <project-number> --owner <owner> --format json`
+
+   Build a lookup map: issue `number` → Project `Status` (`Todo` / `In Progress` / `Done`). Issues absent from the map are classified as "Not in Project."
+
+---
+
+### 2. Compute Report Sections (MANDATORY)
+
+All computations operate on the pre-filtered open-issue set (stubs excluded). Use today's date (UTC) for all age calculations.
+
+#### 2a. Summary Counts
+
+- Total open issues (stub-excluded)
+- Count in Project vs. count not in Project
+
+#### 2b. Distribution by Label Group
+
+For each of the three label groups — `type:*`, `priority:*`, `effort:*` — in canonical order:
+
+- `type:*`: feature, bug, security, performance, dx, tech-debt, reliability, compliance, spike (omit values with 0 count)
+- `priority:*`: P0, P1, P2, P3
+- `effort:*`: XS, S, M, L, XL
+
+For each value present, report count and percentage of total open issues. Add an "_(unlabeled)_" row for issues with no label in that group.
+
+#### 2c. Age Cohorts
+
+Group all open issues by time elapsed since `createdAt` into four ranges:
+
+- `< 7d`
+- `7–30d`
+- `30–90d`
+- `> 90d`
+
+Report count and percentage per range.
+
+#### 2d. Overdue High-Priority Items
+
+- **P0 overdue**: issues with `priority:P0` open longer than 14 days — list with issue number, title, age in days, and assignee (or "unassigned")
+- **P1 overdue**: issues with `priority:P1` open longer than 30 days — list with issue number, title, age in days, and assignee (or "unassigned")
+
+If no overdue items exist in a tier, emit `✅ No overdue <P0/P1> items.`
+
+#### 2e. Stale In-Progress Items
+
+Issues where Project Status = `In Progress` AND `updatedAt` is more than 7 days ago. List with issue number, title, and last-activity date (YYYY-MM-DD).
+
+If none exist, emit `✅ No stale In-Progress items.`
+
+#### 2f. Metadata Debt
+
+Issues missing any of `type:*`, `priority:*`, or `effort:*` labels. For each such issue, note which label group(s) are absent.
+
+If all issues have complete metadata, emit `✅ All open items have complete label metadata.`
+
+---
+
+### 3. Report Assembly (MANDATORY)
+
+Produce a Markdown report with the following sections in this exact order.
+
+#### Header
+
+```text
+## Backlog Health Report
+Generated: <YYYY-MM-DD>
+```
+
+#### Summary
+
+```text
+**Open issues:** N (M in Project, K not in Project)
+```
+
+Stubs excluded from all counts.
+
+#### Distribution
+
+Three tables, one per label group:
+
+_By Type_
+
+| Label         | Count | %   |
+|---------------|-------|-----|
+| type:feature  | N     | N%  |
+| …             | …     | …   |
+| _(unlabeled)_ | N     | N%  |
+
+_By Priority_
+
+| Label       | Count | %   |
+|-------------|-------|-----|
+| priority:P0 | N     | N%  |
+| …           | …     | …   |
+| _(unlabeled)_ | N   | N%  |
+
+_By Effort_
+
+| Label       | Count | %   |
+|-------------|-------|-----|
+| effort:XS   | N     | N%  |
+| …           | …     | …   |
+| _(unlabeled)_ | N   | N%  |
+
+Omit the `_(unlabeled)_` row for a group when its count is 0.
+
+#### Age Cohorts
+
+| Age         | Count | %   |
+|-------------|-------|-----|
+| < 7 days    | N     | N%  |
+| 7–30 days   | N     | N%  |
+| 30–90 days  | N     | N%  |
+| > 90 days   | N     | N%  |
+
+#### Overdue High-Priority Items
+
+_P0 (threshold: >14 days open)_
+
+| Issue        | Title | Age | Assignee |
+|--------------|-------|-----|----------|
+| [#N](<url>) | title | Nd  | @user    |
+
+_P1 (threshold: >30 days open)_
+
+| Issue        | Title | Age | Assignee |
+|--------------|-------|-----|----------|
+| [#N](<url>) | title | Nd  | @user    |
+
+Emit `✅ No overdue P0 items.` / `✅ No overdue P1 items.` when a tier is empty.
+
+#### Stale In-Progress
+
+| Issue        | Title | Last Activity |
+|--------------|-------|---------------|
+| [#N](<url>) | title | YYYY-MM-DD    |
+
+Emit `✅ No stale In-Progress items.` when empty.
+
+#### Metadata Debt
+
+| Issue        | Title | Missing      |
+|--------------|-------|--------------|
+| [#N](<url>) | title | type, effort |
+
+Emit `✅ All open items have complete label metadata.` when empty.
+
+---
+
+## Rules & Constraints
+
+- This command is **strictly read-only** — never mutate any issue, Project field, milestone, or label.
+- Discard `type:external-blocker` stubs before all computations — they are not work items.
+- Closed issues are excluded from all sections.
+- Surface all `gh` errors verbatim — never swallow.
+- Percentages rounded to the nearest integer.
+- "Age" is computed from `createdAt` (UTC); "last activity" from `updatedAt` (UTC).
+- If the Project item-list call fails, emit the error verbatim and omit the Status-dependent sections (Stale In-Progress); continue with all other sections using available data.
+- Do NOT recommend execution order or triage actions — this command surfaces state only.
+
+---
+
+## Output Expectations
+
+The entire output is the Markdown report — no preamble, no trailing summary, no conversational wrapping. The report must be valid GitHub-Flavored Markdown so the user can paste it directly into a standup document, Slack message, or GitHub comment or Discussion.

--- a/skills/github-backlog-management/SKILL.md
+++ b/skills/github-backlog-management/SKILL.md
@@ -18,6 +18,7 @@ A set of slash commands for a fully GitHub-native backlog workflow — Issues, P
 | `/refine-backlog` | Orchestrate a refinement session: list `needs-clarification` candidates, let user select, loop through with `/refine-backlog-item` |
 | `/refine-backlog-item` | Refine a single `needs-clarification` item — discovery dialogue, body rewrite, INVEST gate, label/rank/dep updates, label removal |
 | `/release-status` | Read-only milestone health dashboard — issue counts by Status, blocked items, unestimated items |
+| `/backlog-health` | Read-only strategic portfolio health report — distribution by type/priority/effort, age cohorts, overdue P0/P1 items, stale In-Progress, metadata debt |
 | `/validate-backlog` | Read-only audit — emits actionable `gh` commands; never mutates |
 | `/execute-backlog-item` | Pick the topmost unblocked Todo item and guide it through to a PR |
 
@@ -28,6 +29,7 @@ initialize-backlog ─► plan-release ─► add-backlog-item / migrate-backlog
                                               │
                                               ├─► refine-backlog ─► refine-backlog-item
                                               ├─► release-status (read-only)
+                                              ├─► backlog-health (read-only)
                                               ├─► validate-backlog (read-only)
                                               └─► execute-backlog-item
 ```


### PR DESCRIPTION
## Summary

- Adds `commands/backlog-health.md`, a new read-only command that produces a Markdown strategic portfolio health report across all open issues in the linked Project
- Covers all 8 Acceptance Criteria from issue #21: distribution tables (type/priority/effort), age cohorts, overdue P0/P1 items, stale In-Progress items, and metadata debt
- Follows established command conventions: standard preflight block, label catalog check, `type:external-blocker` stub pre-filter, verbatim `gh` error surfacing, strictly read-only

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)