### PR TITLE
feat: add SessionStart hook for early auth/scope and project-existence warning

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/scripts/session-start-check.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/session-start-check.sh
+++ b/scripts/session-start-check.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+[ -f ".claude/backlog-project.json" ] || exit 0
+
+owner=$(jq -r '.owner' .claude/backlog-project.json)
+project_number=$(jq -r '.project_number' .claude/backlog-project.json)
+project_id=$(jq -r '.project_id' .claude/backlog-project.json)
+
+# --- Check 1: required token scopes ---
+
+auth_status=$(gh auth status --hostname github.com 2>&1)
+scopes_line=$(echo "$auth_status" | grep "Token scopes:")
+
+missing=()
+for scope in repo project read:user; do
+  echo "$scopes_line" | grep -q "'${scope}'" || missing+=("$scope")
+done
+
+owner_type=$(gh api "users/${owner}" --jq '.type' 2>/dev/null)
+if [ "$owner_type" = "Organization" ]; then
+  echo "$scopes_line" | grep -q "'read:org'" || missing+=("read:org")
+fi
+
+if [ ${#missing[@]} -gt 0 ]; then
+  joined=$(IFS=,; echo "${missing[*]}")
+  echo "WARNING: Backlog: missing token scope(s): ${joined}"
+  echo "  Fix: gh auth refresh --scopes ${joined}"
+fi
+
+# --- Check 2: project still exists and ID matches ---
+
+live_id=$(gh project view "$project_number" --owner "$owner" --format json 2>/dev/null | jq -r '.id // empty')
+
+if [ -z "$live_id" ]; then
+  echo "WARNING: Backlog: project #${project_number} not found or inaccessible."
+  echo "  Fix: Re-run /initialize-backlog to re-link the project, or delete .claude/backlog-project.json if the project was abandoned."
+elif [ "$live_id" != "$project_id" ]; then
+  echo "WARNING: Backlog: project ID mismatch (stored: ${project_id}, live: ${live_id})."
+  echo "  Fix: Re-run /initialize-backlog to re-link the project."
+fi
+
+exit 0


### PR DESCRIPTION
Closes #39

## Summary

- Adds `scripts/session-start-check.sh` — runs at session start in any repo with `.claude/backlog-project.json`; silently exits if the file is absent (no noise in unrelated repos)
- Registers it in `hooks/hooks.json` as a `SessionStart` hook via `${CLAUDE_PLUGIN_ROOT}/scripts/session-start-check.sh`
- Always exits 0 — warns but never blocks the session

## What the hook checks

**Check 1 — required token scopes**: parses `gh auth status --hostname github.com` and verifies `repo`, `project`, `read:user` are present (plus `read:org` when the project owner is a GitHub organisation). On failure, emits a banner naming the missing scopes and the exact `gh auth refresh --scopes …` command.

**Check 2 — project still exists**: queries the live project ID via `gh project view` and compares it against the stored `project_id` from `.claude/backlog-project.json`. On mismatch or missing project, emits a banner with the remediation (`/initialize-backlog` or delete the metadata file).

## Acceptance Criteria

| AC | Status |
|---|---|
| `scripts/session-start-check.sh` exists, executable, `#!/usr/bin/env bash` shebang | ✅ |
| `hooks/hooks.json` registers a `SessionStart` hook invoking the script | ✅ |
| Silent when no `.claude/backlog-project.json` present | ✅ tested |
| Silent when token fully scoped + project exists | ✅ (happy path verified) |
| Missing scope → banner + exact `gh auth refresh …` command | ✅ tested |
| Wrong `project_id` → banner + remediation message | ✅ (code path verified) |
| Both failure cases exit 0 | ✅ tested |
| Banner appears at session start, before any prompt | ✅ (SessionStart fires before user input) |

> **Note:** The scratch-repo smoke test (`claude --debug` shows hook registered) and the missing-project-id path require a live install and are not automatable in CI — verify manually before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)