### PR TITLE
feat: add /setup-permissions command and userConfig (#40)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,5 +10,13 @@
   "homepage": "https://github.com/gringolito/github-backlog-management-skill",
   "repository": "https://github.com/gringolito/github-backlog-management-skill",
   "license": "MIT",
-  "keywords": ["github", "backlog", "issues", "projects-v2", "milestones", "labels", "invest", "agile", "prioritization"]
+  "keywords": ["github", "backlog", "issues", "projects-v2", "milestones", "labels", "invest", "agile", "prioritization"],
+  "userConfig": {
+    "permission_mode": {
+      "type": "string",
+      "title": "Permission mode",
+      "description": "yolo = no prompts on gh/git during multi-step commands. safe = read-only gh calls run silently, writes still prompt. off = manage permissions manually (no auto-write).",
+      "default": "off"
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ gh auth refresh --scopes project,read:user
 
 This skill runs multi-step workflows that call `gh` and `git` many times in sequence. Without a pre-approved allowlist, Claude Code prompts for permission on every call and interrupts the workflow mid-run.
 
+When you enable the plugin, Claude Code asks for your preferred mode (`yolo`, `safe`, or `off`). To apply that choice, run:
+
+```text
+/setup-permissions
+```
+
+The command asks which settings file to write (per-project gitignored, per-project shared, or user-global) and merges the allowlist block idempotently — re-running it is safe.
+
+<details>
+<summary>Manual fallback — copy the JSON block directly</summary>
+
 Add one of the blocks below to `.claude/settings.json` in any repo where you use this skill, or to `~/.claude/settings.json` for a global default.
 
 **YOLO mode — no prompts during any multi-step command:**
@@ -127,6 +138,8 @@ Add one of the blocks below to `.claude/settings.json` in any repo where you use
 
 > **Note:** `gh api` calls used for reading milestones and issue dependencies are not listed above — the same command prefix covers both reads and writes, so they cannot be cleanly separated by pattern. In safe mode these calls will still prompt; approve them when the command starts with `gh api "repos/..."` and contains no `-X POST` or `-X DELETE` flag.
 
+</details>
+
 ---
 
 ## Features
@@ -143,6 +156,7 @@ Add one of the blocks below to `.claude/settings.json` in any repo where you use
 | `/backlog-health` | Read-only strategic portfolio health report — open-issue distribution by type, priority, and effort; age cohorts; overdue P0/P1 items; stale In-Progress items; metadata debt. Suitable for leadership updates and retrospectives. |
 | `/validate-backlog` | Read-only audit. Emits actionable `gh issue edit ...` snippets. Never mutates anything. |
 | `/execute-backlog-item` | Picks the topmost unblocked Todo item, respects active milestone scope, skips blocked items, and walks you through to a PR. |
+| `/setup-permissions` | Writes the `gh`/`git` allowlist block into your chosen Claude Code settings file. Idempotent — safe to re-run. |
 
 ### INVEST — the quality bar every backlog item must meet
 

--- a/commands/setup-permissions.md
+++ b/commands/setup-permissions.md
@@ -1,0 +1,140 @@
+---
+description: Write the Claude Code permissions allowlist for this skill into the target settings file.
+---
+
+# setup-permissions
+
+You are an AI agent acting as an installation assistant responsible for configuring Claude Code permission settings for the GitHub Backlog Management skill.
+
+---
+
+## Objective
+
+Write the correct `permissions.allow` block into the user's chosen Claude Code settings file, based on their configured or requested permission mode. This command is idempotent — re-running with the same mode and target is a safe no-op.
+
+---
+
+## Allowlist reference
+
+These are the canonical allowlist blocks for each mode:
+
+**yolo** — no prompts during any multi-step command:
+```json
+["Bash(gh *)", "Bash(git *)"]
+```
+
+**safe** — read-only `gh` calls run silently; write commands still prompt:
+```json
+[
+  "Bash(gh auth status *)",
+  "Bash(gh repo view *)",
+  "Bash(gh issue list *)",
+  "Bash(gh issue view *)",
+  "Bash(gh label list *)",
+  "Bash(gh project list *)",
+  "Bash(gh project view *)",
+  "Bash(gh project item-list *)",
+  "Bash(gh project field-list *)",
+  "Bash(gh release list *)"
+]
+```
+
+---
+
+## Workflow
+
+### 0. Preflight (MANDATORY)
+
+- `gh auth status` — if unauthenticated, STOP and output: `gh auth status failed. Run gh auth login and retry.`
+- Parse `<owner>/<repo>` from `gh repo view --json owner,name`
+
+---
+
+### 1. Mode Resolution (MANDATORY)
+
+Determine the effective permission mode using this precedence:
+
+1. **Explicit argument** — if the user passed a mode as an argument to this command (e.g. `/setup-permissions safe`), use it. This overrides the configured value for this invocation only; it does not change the stored `userConfig`.
+2. **`${CLAUDE_PLUGIN_OPTION_PERMISSION_MODE}`** — the value set at plugin enable time via `userConfig`.
+3. **Fallback** — treat as `off` if neither is set.
+
+Valid values: `yolo`, `safe`, `off`. If the resolved value is anything else, STOP and output: `Unknown permission mode "<value>". Valid values: yolo, safe, off.`
+
+---
+
+### 2. Off / Unset path (STRICT)
+
+If the resolved mode is `off`:
+
+- Print exactly: `Permission mode is "off" — no settings written. See README "Authentication & Permissions" for manual configuration.`
+- STOP. Do not read, write, or touch any settings file.
+
+---
+
+### 3. Target file selection (MANDATORY)
+
+Ask the user which file to write. Present exactly three options:
+
+1. `.claude/settings.local.json` — per-project, gitignored (recommended for personal setups)
+2. `.claude/settings.json` — per-project, version-controlled (for shared team config)
+3. `~/.claude/settings.json` — user-global (applies to every Claude Code session)
+
+Wait for the user to select one before proceeding.
+
+---
+
+### 4. Idempotent merge and write (STRICT)
+
+1. **Read** the chosen target file. If it does not exist, treat its content as `{}`.
+2. Parse the JSON. If parsing fails, STOP and output: `Could not parse <target>: <parse error>. Fix the file manually before retrying.`
+3. Resolve `permissions.allow` as a list (default `[]` if absent).
+4. Determine the rules to add from the **Allowlist reference** section for the resolved mode.
+5. **Merge idempotently**: for each rule in the mode's list, append it only if it is not already present. Never remove or reorder existing entries.
+6. If no new rules were added (all already present): print `No changes — all rules already present in <target>.` and STOP.
+7. Write the updated JSON back to the target file with 2-space indentation.
+
+---
+
+### 5. Verification (MANDATORY)
+
+Re-read the target file and confirm all expected rules are present. Output the result summary (see Output Expectations).
+
+---
+
+## Rules & Constraints
+
+- NEVER write to a settings file without explicit user confirmation of the target (step 3)
+- NEVER remove or reorder existing entries in `permissions.allow`
+- NEVER write settings when mode is `off` — that path is strictly read-only and exit-only
+- An explicit argument overrides `userConfig` for this invocation ONLY — do NOT persist or modify the stored `userConfig` value
+- Surface all `gh` errors and file I/O errors verbatim — never swallow
+- If the target file path contains `~`, expand it to the user's home directory using `$HOME`
+
+---
+
+## Output Expectations
+
+**Off mode:**
+```
+Permission mode is "off" — no settings written. See README "Authentication & Permissions" for manual configuration.
+```
+
+**Successful write:**
+```
+✓ Wrote <N> rules to <target> (mode: <mode>)
+Rules added:
+  - Bash(gh *)
+  - Bash(git *)
+Rules already present: (none | <list>)
+```
+
+**No-op (all rules already present):**
+```
+No changes — all rules already present in <target>.
+```
+
+**Error cases:**
+- Auth failure: `gh auth status failed. Run gh auth login and retry.`
+- Unknown mode: `Unknown permission mode "<value>". Valid values: yolo, safe, off.`
+- JSON parse error: `Could not parse <target>: <parse error>. Fix the file manually before retrying.`
+- All `gh` errors surfaced verbatim


### PR DESCRIPTION
## Summary

- Adds `userConfig.permission_mode` field to `plugin.json` — Claude Code prompts for `yolo`/`safe`/`off` at install time
- Adds `commands/setup-permissions.md` — on-demand command that writes the matching allowlist block idempotently into the user's chosen settings file (per-project gitignored, per-project shared, or user-global)
- Collapses README's 70-line "Configure Claude Code permissions" section into a one-paragraph pointer to `/setup-permissions`; original JSON blocks preserved in a `<details>` manual fallback

## Acceptance Criteria coverage

- [x] `plugin.json` declares `userConfig.permission_mode` with values `yolo`/`safe`/`off` and `default: "off"`
- [x] `commands/setup-permissions.md` exists, follows standard command spec style (`(MANDATORY)`/`(STRICT)` flags, `Rules & Constraints`, `Output Expectations`)
- [x] When mode is `off` or unset, `/setup-permissions` prints a one-line note and exits without writing
- [x] When mode is `yolo` or `safe`, command prompts for target file (3 options), writes matching allowlist block idempotently
- [x] Re-running with same mode and target is a silent no-op (idempotent)
- [x] Optional argument `/setup-permissions <mode>` overrides userConfig for that invocation only
- [x] README's "Authentication & Permissions" section collapsed: JSON blocks in `<details>` fallback, primary path is `/setup-permissions`

## Notes

- `setup-permissions` intentionally omits the `.claude/backlog-project.json` preflight — it is a first-time setup utility that runs before `/initialize-backlog`
- `TODO.md` and an unrelated pre-existing change to `execute-backlog-item.md` are NOT included in this PR

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)