### PR TITLE
fix: remove redundant gh issue list call from execute-backlog-item

### DIFF
--- a/commands/execute-backlog-item.md
+++ b/commands/execute-backlog-item.md
@@ -72,7 +72,6 @@ Use these `gh` calls to gather data:
 - Project candidates — use targeted queries:
   - Tier 1: `gh project item-list <project-number> --owner <owner> --format json --limit 200 --query "is:issue status:Todo milestone:<active-milestone-title>"`
   - Tier 2: `gh project item-list <project-number> --owner <owner> --format json --limit 200 --query "is:issue status:Todo no:milestone"`
-- Issues: `gh issue list --state open --json number,title,labels,milestone,url --limit 200`
 
 ---
 


### PR DESCRIPTION
## Summary

- Removes the broad `gh issue list` call that was superseded by the targeted `gh project item-list` Tier 1/Tier 2 queries introduced in #77
- Every field that call returned (`number`, `title`, `labels`, `milestone`, `url`) is already available from the project-ranked result set and the per-item `gh issue view` fetch at execution time
- Eliminates noise and the risk of the agent confusing an issue-list result with the project-ranked result

🤖 Generated with [Claude Code](https://claude.com/claude-code)