### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
         "source": "github",
         "repo": "gringolito/github-backlog-management-skill"
       },
-      "version": "0.2.0",
+      "version": "0.3.0",
       "category": "productivity",
       "keywords": ["github", "backlog", "issues", "projects-v2", "milestones", "labels", "invest", "agile", "prioritization"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "github-backlog-management",
   "description": "GitHub-native backlog automation. Manage Issues + Projects v2 with AI-enforced INVEST quality, dependency tracking, and one-command execution.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "Filipe Utzig",
     "email": "filipe@gringolito.com"


### PR DESCRIPTION
Release prep for v0.3.0. Milestone: https://github.com/gringolito/github-backlog-management-skill/milestone/3.

- Bump `.claude-plugin/plugin.json` version: `0.2.0` → `0.3.0`
- Bump `.claude-plugin/marketplace.json` version: `0.2.0` → `0.3.0`