### PR TITLE
fix: include all required dirs in release zip bundle

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
         run: |
           ZIP_NAME="github-backlog-management-${GITHUB_REF_NAME}.zip"
           mkdir github-backlog-management
-          cp -r commands/ README.md SKILL.md LICENSE github-backlog-management/
+          cp -r commands/ skills/ hooks/ scripts/ .claude-plugin/ README.md LICENSE github-backlog-management/
           zip -r "${ZIP_NAME}" github-backlog-management/
           echo "ZIP_NAME=${ZIP_NAME}" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Summary

- Replaces stale `SKILL.md` reference with `skills/` in the `cp` command (file was moved to `skills/github-backlog-management/SKILL.md` in PR #70)
- Adds `hooks/`, `scripts/`, and `.claude-plugin/` to the release zip — these were never included, making all distributed packages incomplete

## Acceptance Criteria

- [x] `release.yaml` `cp` command no longer references `SKILL.md`
- [x] `skills/`, `hooks/`, `scripts/`, and `.claude-plugin/` are all present in the `cp` command
- [x] A tag push triggers a green GitHub Actions release run
- [x] The resulting zip contains: `commands/`, `skills/`, `hooks/`, `scripts/`, `.claude-plugin/`, `README.md`, `LICENSE`

The last two ACs are verified by the release run that follows merging this PR.

Closes #82