### PR TITLE
chore(release): prepare v0.3.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
         "source": "github",
         "repo": "gringolito/github-backlog-management-skill"
       },
-      "version": "0.3.1",
+      "version": "0.3.2",
       "category": "productivity",
       "keywords": ["github", "backlog", "issues", "projects-v2", "milestones", "labels", "invest", "agile", "prioritization"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "github-backlog-management",
   "description": "GitHub-native backlog automation. Manage Issues + Projects v2 with AI-enforced INVEST quality, dependency tracking, and one-command execution.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": {
     "name": "Filipe Utzig",
     "email": "filipe@gringolito.com"


### PR DESCRIPTION
Release prep for v0.3.2. Milestone: https://github.com/gringolito/github-backlog-management-skill/milestone/5.

Bumps `plugin.json` and `marketplace.json` version from `0.3.1` → `0.3.2` per policy: version bumps happen at release closure, not per PR.