### PR TITLE
chore: add agent skills configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,3 +82,17 @@ There is no automated test suite. The end-to-end smoke is:
 7. `/validate-backlog` → seed deliberate violations (missing `priority:*`, dangling blocker, cross-Project blocker) and confirm they appear in the Critical/Quality/Consistency report sections.
 8. `/backlog-health` → confirm Markdown report renders all six sections (summary, distribution tables, age cohorts, overdue P0/P1, stale In-Progress, metadata debt); verify stubs excluded from counts; confirm zero mutations.
 9. `/refine-backlog` → presents the `needs-clarification` queue, user selects items, loop delegates to `/refine-backlog-item`; label removed only after pre-removal validation gate passes.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues, managed via the `github-backlog-management-skill`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+This repo uses the `github-backlog-management-skill`'s own label classification (`type:*`, `priority:*`, `effort:*`) rather than the canonical triage roles. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context repo: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-example-decision.md
+│   └── ...
+└── commands/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (example) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,21 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub Issues, managed via the `github-backlog-management-skill`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Call the `/add-backlog-item` skill — do not call `gh issue create` directly.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,12 @@
+# Triage Labels
+
+This repo uses the `github-backlog-management-skill`'s own label classification system rather than the canonical five triage roles. Do not apply `needs-triage`, `ready-for-agent`, etc. — use the labels defined by the skill instead.
+
+## Label catalog
+
+- **Type**: `type:feature`, `type:bug`, `type:security`, `type:performance`, `type:dx`, `type:tech-debt`, `type:reliability`, `type:compliance`, `type:spike`, `type:external-blocker`
+- **Priority**: `priority:P0`, `priority:P1`, `priority:P2`, `priority:P3`
+- **Effort**: `effort:XS`, `effort:S`, `effort:M`, `effort:L`, `effort:XL`
+- **Special**: `needs-clarification`
+
+See `CLAUDE.md` for full invariants governing these labels.


### PR DESCRIPTION
## Summary

- Adds `## Agent skills` block to `CLAUDE.md` pointing skills at the three config docs
- Creates `docs/agents/issue-tracker.md` — GitHub Issues via `/add-backlog-item` (not direct `gh issue create`)
- Creates `docs/agents/triage-labels.md` — documents the skill's own `type:*`/`priority:*`/`effort:*` label catalog in place of canonical triage roles
- Creates `docs/agents/domain.md` — single-context layout (`CONTEXT.md` + `docs/adr/` at repo root)

🤖 Generated with [Claude Code](https://claude.com/claude-code)