### PR TITLE
refactor: extract INVEST validation into reusable invest-gate subagent

### DIFF
--- a/agents/invest-gate.md
+++ b/agents/invest-gate.md
@@ -1,0 +1,73 @@
+---
+name: invest-gate
+model: haiku
+effort: low
+disallowedTools: Write, Edit
+description: Returns PASS/FAIL per INVEST letter for a given issue body, with one-line reasoning per criterion. Invoke when a backlog item needs gating.
+---
+
+# invest-gate
+
+You are a stateless INVEST validator. Your sole job is to evaluate a backlog item against the six INVEST principles and return a structured per-letter verdict.
+
+You do NOT create, edit, or delete any files or issues. You only read the input provided and return a verdict.
+
+---
+
+## Input Contract
+
+You receive one or more of the following:
+
+- **Issue body** (required) — the full markdown body of the backlog item, expected to contain sections: `### What`, `### Why`, `### In Scope`, `### Out of Scope`, `### Acceptance Criteria`, `### INVEST Notes`
+- **Title** (optional) — the issue title
+- **Labels** (optional) — applied labels (e.g. `type:feature`, `priority:P1`, `effort:M`)
+
+---
+
+## INVEST Rubric
+
+| Letter | Criterion   | Definition |
+|--------|-------------|------------|
+| **I**  | Independent | The item has no hidden dependency on another unfinished item that would prevent it from being started or estimated in isolation. Explicitly declared dependencies (e.g. "blocked by #N") are fine — hidden coupling (shared mutable state, sequential data migrations, implicit ordering) is a violation. |
+| **N**  | Negotiable  | The item describes WHAT is needed, not HOW to implement it. Hard-wired technology choices, specific file names, or mandatory code patterns are violations unless they are themselves the acceptance criteria (e.g. a migration to a specific library). |
+| **V**  | Valuable    | The item delivers a clear, stated benefit to a user, the system, or the business. Internal work (refactors, debt cleanup) is valuable if `### Why` explains the benefit explicitly. An empty or `_No response_` `### Why` is a violation. |
+| **E**  | Estimable   | The `### In Scope`, `### Acceptance Criteria`, and `### What` sections together contain enough detail for a developer to form a complexity estimate. `UNKNOWN`, `NEEDS CLARIFICATION`, or `_No response_` in any required section is a violation. |
+| **S**  | Small       | The item can be delivered in a single iteration. Signs it is too large: more than ~5 acceptance criteria, criteria that imply multiple independent deliverables, or an `effort:XL` label with no split plan noted. |
+| **T**  | Testable    | Every non-blank line in `### Acceptance Criteria` MUST begin with `- [ ]`. Vague criteria ("works correctly", "improves performance") are violations even with the correct prefix — all criteria must be objectively verifiable. |
+
+---
+
+## Output Schema
+
+Return EXACTLY this structure — no prose before or after:
+
+```
+I: PASS|FAIL — <one-line reasoning>
+N: PASS|FAIL — <one-line reasoning>
+V: PASS|FAIL — <one-line reasoning>
+E: PASS|FAIL — <one-line reasoning>
+S: PASS|FAIL — <one-line reasoning>
+T: PASS|FAIL — <one-line reasoning>
+
+Overall: PASS|FAIL
+```
+
+For **T (Testable)**: if any non-blank line in `### Acceptance Criteria` does not begin with `- [ ]`, list each offending line below the T verdict line:
+
+```
+T: FAIL — <count> line(s) in ### Acceptance Criteria do not begin with `- [ ]`
+  Offending: <original line>
+  Corrected: - [ ] <text>
+```
+
+**Overall verdict**: `PASS` only if ALL six letters are `PASS`. Any single `FAIL` produces `Overall: FAIL`.
+
+---
+
+## Rules & Constraints
+
+- Return ONLY the structured output — no explanation headers, no summaries, no preamble
+- Do NOT suggest fixes beyond the T-violation correction slots above
+- Do NOT fetch any external data — evaluate only what is provided
+- Do NOT write or edit any files
+- If the issue body is missing or empty: return `Overall: FAIL` with `E: FAIL — no issue body provided` and all other letters `FAIL — cannot evaluate without body`

--- a/agents/invest-gate.md
+++ b/agents/invest-gate.md
@@ -26,14 +26,14 @@ You receive one or more of the following:
 
 ## INVEST Rubric
 
-| Letter | Criterion   | Definition |
-|--------|-------------|------------|
-| **I**  | Independent | The item has no hidden dependency on another unfinished item that would prevent it from being started or estimated in isolation. Explicitly declared dependencies (e.g. "blocked by #N") are fine — hidden coupling (shared mutable state, sequential data migrations, implicit ordering) is a violation. |
-| **N**  | Negotiable  | The item describes WHAT is needed, not HOW to implement it. Hard-wired technology choices, specific file names, or mandatory code patterns are violations unless they are themselves the acceptance criteria (e.g. a migration to a specific library). |
-| **V**  | Valuable    | The item delivers a clear, stated benefit to a user, the system, or the business. Internal work (refactors, debt cleanup) is valuable if `### Why` explains the benefit explicitly. An empty or `_No response_` `### Why` is a violation. |
-| **E**  | Estimable   | The `### In Scope`, `### Acceptance Criteria`, and `### What` sections together contain enough detail for a developer to form a complexity estimate. `UNKNOWN`, `NEEDS CLARIFICATION`, or `_No response_` in any required section is a violation. |
-| **S**  | Small       | The item can be delivered in a single iteration. Signs it is too large: more than ~5 acceptance criteria, criteria that imply multiple independent deliverables, or an `effort:XL` label with no split plan noted. |
-| **T**  | Testable    | Every non-blank line in `### Acceptance Criteria` MUST begin with `- [ ]`. Vague criteria ("works correctly", "improves performance") are violations even with the correct prefix — all criteria must be objectively verifiable. |
+| Letter | Criterion | Definition |
+| ------ | --------- | ---------- |
+| **I** | Independent | The item has no hidden dependency on another unfinished item that would prevent it from being started or estimated in isolation. Explicitly declared dependencies (e.g. "blocked by #N") are fine — hidden coupling (shared mutable state, sequential data migrations, implicit ordering) is a violation. |
+| **N** | Negotiable | The item describes WHAT is needed, not HOW to implement it. Hard-wired technology choices, specific file names, or mandatory code patterns are violations unless they are themselves the acceptance criteria (e.g. a migration to a specific library). |
+| **V** | Valuable | The item delivers a clear, stated benefit to a user, the system, or the business. Internal work (refactors, debt cleanup) is valuable if `### Why` explains the benefit explicitly. An empty or `_No response_` `### Why` is a violation. |
+| **E** | Estimable | The `### In Scope`, `### Acceptance Criteria`, and `### What` sections together contain enough detail for a developer to form a complexity estimate. `UNKNOWN`, `NEEDS CLARIFICATION`, or `_No response_` in any required section is a violation. |
+| **S** | Small | The item can be delivered in a single iteration. Signs it is too large: more than ~5 acceptance criteria, criteria that imply multiple independent deliverables, or an `effort:XL` label with no split plan noted. |
+| **T** | Testable | Each criterion in `### Acceptance Criteria` must be objectively verifiable by a third party. Vague criteria ("works correctly", "improves performance", "is better") are violations. |
 
 ---
 
@@ -52,14 +52,6 @@ T: PASS|FAIL — <one-line reasoning>
 Overall: PASS|FAIL
 ```
 
-For **T (Testable)**: if any non-blank line in `### Acceptance Criteria` does not begin with `- [ ]`, list each offending line below the T verdict line:
-
-```
-T: FAIL — <count> line(s) in ### Acceptance Criteria do not begin with `- [ ]`
-  Offending: <original line>
-  Corrected: - [ ] <text>
-```
-
 **Overall verdict**: `PASS` only if ALL six letters are `PASS`. Any single `FAIL` produces `Overall: FAIL`.
 
 ---
@@ -67,7 +59,7 @@ T: FAIL — <count> line(s) in ### Acceptance Criteria do not begin with `- [ ]`
 ## Rules & Constraints
 
 - Return ONLY the structured output — no explanation headers, no summaries, no preamble
-- Do NOT suggest fixes beyond the T-violation correction slots above
+- Do NOT suggest fixes
 - Do NOT fetch any external data — evaluate only what is provided
 - Do NOT write or edit any files
 - If the issue body is missing or empty: return `Overall: FAIL` with `E: FAIL — no issue body provided` and all other letters `FAIL — cannot evaluate without body`

--- a/commands/add-backlog-item.md
+++ b/commands/add-backlog-item.md
@@ -82,23 +82,20 @@ Type, Priority, and Effort are NOT in the body — they are applied as repositor
 
 ### 4. INVEST Enforcement (MANDATORY)
 
-Validate that the item is:
+Delegate to the `invest-gate` agent with the body constructed in step 3 and the issue title.
 
-- Independent → No hidden dependencies on other items
-- Negotiable → Not overly prescriptive in implementation
-- Valuable → Clear benefit to user or system
-- Estimable → Enough detail to assess complexity
-- Small → Can be delivered in a single iteration
-- Testable → Acceptance criteria are verifiable and in the correct format. **Format check (MANDATORY):** Every non-blank line in `### Acceptance Criteria` MUST begin with `- [ ]`. If any line does not match:
-  - STOP
-  - List each offending line and show its corrected `- [ ] <text>` form
-  - Propose corrected versions; require user approval before creation proceeds
-
-If any principle fails:
+If `invest-gate` returns `Overall: FAIL`:
 
 - STOP
-- Explain the issue
-- Propose a corrected version
+- Show the per-letter verdict to the user
+- For any `FAIL` letter, propose a corrected version of the relevant section
+- Do NOT proceed to step 5 until the user approves corrections and `invest-gate` returns `Overall: PASS`
+
+If `invest-gate` returns a T violation with offending lines:
+
+- STOP
+- Show each offending line with its corrected `- [ ] <text>` form (as returned by `invest-gate`)
+- Require user approval before proceeding
 
 ---
 

--- a/commands/add-backlog-item.md
+++ b/commands/add-backlog-item.md
@@ -91,12 +91,6 @@ If `invest-gate` returns `Overall: FAIL`:
 - For any `FAIL` letter, propose a corrected version of the relevant section
 - Do NOT proceed to step 5 until the user approves corrections and `invest-gate` returns `Overall: PASS`
 
-If `invest-gate` returns a T violation with offending lines:
-
-- STOP
-- Show each offending line with its corrected `- [ ] <text>` form (as returned by `invest-gate`)
-- Require user approval before proceeding
-
 ---
 
 ### 5. Priority Classification

--- a/commands/migrate-backlog.md
+++ b/commands/migrate-backlog.md
@@ -120,20 +120,13 @@ If unclear:
 
 ### 6. INVEST Evaluation
 
-For each item:
+For each item, delegate to the `invest-gate` agent with the normalized body and title.
 
-- Validate:
-  - Independent
-  - Negotiable
-  - Valuable
-  - Estimable
-  - Small
-  - Testable
+If `invest-gate` returns `Overall: FAIL`:
 
-If violations exist:
-
-- Capture them in `### INVEST Notes`
-- Suggest improvements (do NOT silently rewrite intent)
+- Capture each `FAIL` letter's reasoning in `### INVEST Notes`
+- Suggest improvements in the Migration Report (do NOT silently rewrite intent)
+- Apply the `needs-clarification` label to the item
 
 ---
 

--- a/commands/refine-backlog-item.md
+++ b/commands/refine-backlog-item.md
@@ -102,26 +102,22 @@ DO NOT introduce new headings or change ordering — `validate-backlog` parses t
 
 ### 5. INVEST Gate (MANDATORY)
 
-Validate the refined item against:
+Delegate to the `invest-gate` agent with the reconstructed body from step 4 and the issue title.
 
-- Independent
-- Negotiable
-- Valuable
-- Estimable
-- Small
-- Testable — every non-blank line in `### Acceptance Criteria` MUST begin with `- [ ]`. If any line does not match:
-  - List each offending line and show its corrected `- [ ] <text>` form
-  - Propose corrected versions; require user approval before applying the body update
+If `invest-gate` returns a T violation with offending lines:
 
-If any principle still fails after refinement:
+- Show each offending line with its corrected `- [ ] <text>` form (as returned by `invest-gate`)
+- Require user approval before applying the body update
 
-- Capture the violation in `### INVEST Notes`
+If `invest-gate` returns `Overall: FAIL` (after incorporating any T fixes, or for non-T principle failures):
+
+- Capture each `FAIL` letter's reasoning in `### INVEST Notes`
 - Apply the partial body update (step 6), but SKIP steps 7–10
 - KEEP the `needs-clarification` label
-- Output the partial-refinement result: issue URL + list of INVEST failures + what remains in `### INVEST Notes`
+- Output the partial-refinement result: issue URL + per-letter INVEST verdict from `invest-gate` + what remains in `### INVEST Notes`
 - STOP — do not continue to label/rank re-evaluation or label removal
 
-If splitting is needed (item too large to be Small):
+If splitting is needed (S letter fails):
 
 - Suggest a split via `/add-backlog-item` for the new item(s)
 - Apply the partial body update reflecting the reduced scope of the original item, OR keep the original as-is if the user prefers to handle the split manually

--- a/commands/refine-backlog-item.md
+++ b/commands/refine-backlog-item.md
@@ -104,12 +104,7 @@ DO NOT introduce new headings or change ordering — `validate-backlog` parses t
 
 Delegate to the `invest-gate` agent with the reconstructed body from step 4 and the issue title.
 
-If `invest-gate` returns a T violation with offending lines:
-
-- Show each offending line with its corrected `- [ ] <text>` form (as returned by `invest-gate`)
-- Require user approval before applying the body update
-
-If `invest-gate` returns `Overall: FAIL` (after incorporating any T fixes, or for non-T principle failures):
+If `invest-gate` returns `Overall: FAIL`:
 
 - Capture each `FAIL` letter's reasoning in `### INVEST Notes`
 - Apply the partial body update (step 6), but SKIP steps 7–10

--- a/commands/validate-backlog.md
+++ b/commands/validate-backlog.md
@@ -132,19 +132,14 @@ Flag:
 
 ### 4. INVEST Validation (MANDATORY)
 
-For EACH item, evaluate:
+For EACH item, delegate to the `invest-gate` agent with the item's full body and title.
 
-- Independent → no hidden dependencies
-- Negotiable → not overly prescriptive
-- Valuable → clear benefit
-- Estimable → enough detail
-- Small → not too large for a single iteration
-- Testable → acceptance criteria are verifiable
+Collect all `FAIL` verdicts across items. For each violation:
 
-For each violation:
+- Include the per-letter reasoning returned by `invest-gate`
+- Suggest an improvement
 
-- Explain why
-- Suggest improvement
+Report all INVEST violations in section **B. Quality Issues**.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `agents/invest-gate.md` — a Haiku subagent that accepts an issue body + title and returns a structured per-letter PASS/FAIL verdict with one-line reasoning per INVEST criterion
- Removes the duplicated inline INVEST rubric from four command files (`add-backlog-item`, `migrate-backlog`, `refine-backlog-item`, `validate-backlog`), replacing each with a delegation call to `invest-gate`
- Net: −48 lines of duplicated rubric prose, +102 lines of single authoritative agent definition

## Acceptance Criteria

- [x] `agents/invest-gate.md` exists with the specified frontmatter (`name: invest-gate`, `model: haiku`, `effort: low`, `disallowedTools: Write, Edit`)
- [x] All four caller commands delegate to `invest-gate` and contain no inline INVEST prompt logic
- [x] Output schema documented in the agent body (per-letter PASS/FAIL + one-line reasoning + overall verdict) and delegation is consistent across all four callers
- [ ] In a scratch repo, `/add-backlog-item` for a deliberately under-specified item produces a per-letter FAIL report from `invest-gate` *(manual smoke test — requires live GitHub repo)*
- [ ] `claude --debug` shows the agent registered *(manual verification)*
- [x] CLAUDE.md consistency greps all pass (type labels ×10, priority labels ×4, effort labels ×5, preflight stop string ×13, no bucket/Bucket occurrences)

Closes #35