### PR TITLE
refactor: extract dependency-inferrer subagent (#36)

### DIFF
--- a/agents/dependency-inferrer.md
+++ b/agents/dependency-inferrer.md
@@ -1,0 +1,81 @@
+---
+name: dependency-inferrer
+model: haiku
+effort: low
+disallowedTools: Write, Edit
+description: Surfaces candidate "depends on / blocked by" relationships from prose. Returns a structured candidate list for user review; never applies anything.
+---
+
+# dependency-inferrer
+
+You are a stateless dependency analyst. Your sole job is to scan prose text for hints of dependency relationships between backlog items and return a structured candidate list for user review.
+
+You do NOT create, edit, or delete any files or issues. You do NOT apply any dependency relationships. You only read the input provided and return candidates.
+
+---
+
+## Input Contract
+
+You receive:
+
+- **Prose text** (required) — one or more backlog item descriptions, issue bodies, or migration source text, each identified by a source title or issue number
+- **Issue roster** (required) — a list of issue numbers and titles currently in scope (e.g. `#12 "Add OAuth login"`)
+
+---
+
+## Pattern Library
+
+Scan for phrases that signal dependency relationships:
+
+| Relationship type | Example phrases |
+| --- | --- |
+| `blocked_by` | "depends on", "depends upon", "blocked by", "after X is done", "after X", "before X can start", "requires X first", "requires", "prerequisite", "needs X first" |
+| `blocking` | "blocks", "blocking", "must be done before X", "before X" |
+| `sub_issue` | "sub-task of", "part of", "child of", "parent: X" |
+
+---
+
+## Output Schema
+
+Return EXACTLY this structure — no prose before or after:
+
+```
+CANDIDATES:
+
+#<source-num> "<source-title>"
+  → <relationship-type>: #<target-num> "<target-title>"
+    confidence: HIGH|MEDIUM|LOW
+    evidence: "<exact phrase from prose that triggered this match>"
+```
+
+Repeat the block for each candidate. If no candidates are found, output:
+
+```
+CANDIDATES: none
+```
+
+If a hint references a target that is NOT in the issue roster, output:
+
+```
+  → <relationship-type>: UNRESOLVED — "<referenced target from prose>"
+    confidence: LOW
+    evidence: "<exact phrase>"
+```
+
+**Confidence levels:**
+
+- `HIGH` — phrase is an exact match to a known pattern and the target is unambiguously identified by issue number or exact title match in the roster
+- `MEDIUM` — phrase matches a pattern but the target is resolved by fuzzy title match or partial reference
+- `LOW` — phrase suggests a dependency but the target is unclear or could match multiple items
+
+---
+
+## Rules & Constraints
+
+- Return ONLY the structured output — no explanation headers, no summaries, no preamble
+- Do NOT apply any dependency relationships
+- Do NOT fetch any external data — evaluate only what is provided
+- Do NOT write or edit any files
+- Do NOT guess target issues that are not clearly referenced in the prose
+- Scan each item's prose independently; do not infer cross-item deps unless the prose explicitly references another item
+- If the prose text is empty or missing: output `CANDIDATES: none`

--- a/commands/migrate-backlog.md
+++ b/commands/migrate-backlog.md
@@ -41,13 +41,6 @@ Transform ALL existing backlog items into GitHub Issues while:
 - Parse the source backlog provided by the user (markdown, plain text, or any structured form)
 - Identify individual items (even if poorly structured)
 - Preserve original intent and wording
-- **Scan for dependency hints** in each item's prose. Look for phrases such as:
-  - "depends on", "depends upon"
-  - "blocked by", "blocks", "blocking"
-  - "after X is done", "before X", "requires X first"
-  - "sub-task of", "part of", "child of", "parent: X"
-  - "requires", "prerequisite"
-- For each hint, capture: the source item, the phrase matched, and the referenced target (by source title or any explicit identifier). DO NOT apply anything yet — these are candidate dependencies for user review in step 9d.
 
 If item boundaries are unclear:
 
@@ -225,21 +218,21 @@ This map is used in 9e to resolve dependency hints to concrete issue IDs.
 
 #### 9e. Propose and apply dependencies (USER-CONFIRMED)
 
-For each dependency hint captured in step 1:
+1. **Delegate to `dependency-inferrer`.** Call the `dependency-inferrer` agent with:
+   - **Prose**: the full source text of each migrated item (from Step 1 parsing), one entry per item labeled with its source title
+   - **Issue roster**: the source-title → issue-number map from Step 9d, formatted as `#<num> "<title>"` per line
+   If the agent returns `CANDIDATES: none`, skip the rest of this step.
 
-1. **Resolve the target.** Try to match the hint's referenced title against the source-title → issue-id map.
-   - If the target is a Done item that was skipped (9a), skip the hint and note it in the Migration Report (the dep would point at nothing in GitHub)
-   - If the target can't be matched to any source item, surface as a "manual resolution needed" entry in the Migration Report — DO NOT guess
-2. **Classify the relationship type:**
-   - "depends on" / "blocked by" / "after" / "requires" / "prerequisite" → `blocked_by`
-   - "blocks" / "blocking" / "before X" → `blocking`
-   - "sub-task of" / "part of" / "child of" / "parent: X" → sub-issue parent
+2. **Resolve each candidate against the source-title → issue-id map** (from Step 9d):
+   - `UNRESOLVED` targets: surface as "manual resolution needed" in the Migration Report — DO NOT guess
+   - Candidates pointing at a Done item (skipped in 9a): skip the candidate and note it in the Migration Report
+
 3. **Present all candidates to the user in a single review block** (NOT one-by-one) so they can scan and confirm in bulk. Format:
 
    ```text
    #<this-num> "<this-title>"
-     → blocked_by #<target-num> "<target-title>" (matched phrase: "depends on the API spec")
-     → sub-issue of #<parent-num> "<parent-title>" (matched phrase: "part of API rework")
+     → blocked_by #<target-num> "<target-title>" (evidence: "depends on the API spec")
+     → sub-issue of #<parent-num> "<parent-title>" (evidence: "part of API rework")
    ```
 
 4. **Apply only after explicit confirmation.** The user can accept all, reject all, or cherry-pick. For each accepted candidate:

--- a/commands/refine-backlog-item.md
+++ b/commands/refine-backlog-item.md
@@ -77,6 +77,10 @@ Reuse the discovery pattern from `add-backlog-item`:
   - User/business impact
   - Constraints, risks, edge cases
 - Revisit the displayed relationships:
+  - **Dependency scan**: delegate to the `dependency-inferrer` agent with:
+    - **Prose**: the full issue body (all sections concatenated)
+    - **Issue roster**: the list of open issues in the Project (`gh issue list --state open --json number,title --limit 200 | jq -r '.[] | "#\(.number) \"\(.title)\""'`)
+    If the agent returns any candidates, present them to the user as starting proposals for the relationship review. `UNRESOLVED` targets are surfaced as open questions for the user to clarify.
   - Are existing blockers still relevant? Should any be removed via `gh api -X DELETE "repos/<owner>/<repo>/issues/<n>/dependencies/blocked_by/<blocker-id>"`?
   - Did refinement reveal NEW blockers? (issue numbers; cross-repo allowed)
   - Should the sub-issue parent change or be removed?


### PR DESCRIPTION
## Summary

- **New agent** `agents/dependency-inferrer.md`: stateless haiku subagent that scans prose for dependency hints and returns a structured `CANDIDATES` block with confidence levels and source-quote evidence. Declares `disallowedTools: Write, Edit` — never mutates anything.
- **`commands/migrate-backlog.md`**: removes inline phrase-scanning from Step 1; Step 9e now delegates to `dependency-inferrer` to surface candidates, then resolves against the post-creation issue roster and presents to the user for confirmation.
- **`commands/refine-backlog-item.md`**: Step 3 relationship review now opens with a `dependency-inferrer` scan of the full issue body before the manual blocker questions, surfacing any embedded hints as starting proposals.

User-confirmation gate preserved in both callers (locked design decision: dep inference is opt-in, never auto-applied).

## Acceptance Criteria Status

- [x] `agents/dependency-inferrer.md` exists with the specified frontmatter (`name`, `model: haiku`, `effort: low`, `disallowedTools: Write, Edit`, `description`)
- [x] Both `migrate-backlog` and `refine-backlog-item` delegate to the agent; no inline pattern-matching logic remains
- [x] Output schema (`CANDIDATES` block with `confidence` and `evidence` per candidate) documented in the agent and consistent across callers
- [ ] Scratch-repo smoke test: `/migrate-backlog` against a fixture `BACKLOG.md` with "depends on the indexing rewrite" surfaces the candidate via the agent — **requires manual verification in a live repo**
- [x] No dependency auto-applied without user confirmation in either caller (`NEVER auto-apply` + confirmation gate preserved)
- [ ] `claude --debug` shows agent registered — **requires manual verification** (agent file follows the same format as the already-registered `invest-gate` agent)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)