### PR TITLE
refactor: extract label-classifier subagent

### DIFF
--- a/agents/invest-gate.md
+++ b/agents/invest-gate.md
@@ -32,7 +32,7 @@ You receive one or more of the following:
 | **N** | Negotiable | The item describes WHAT is needed, not HOW to implement it. Hard-wired technology choices, specific file names, or mandatory code patterns are violations unless they are themselves the acceptance criteria (e.g. a migration to a specific library). |
 | **V** | Valuable | The item delivers a clear, stated benefit to a user, the system, or the business. Internal work (refactors, debt cleanup) is valuable if `### Why` explains the benefit explicitly. An empty or `_No response_` `### Why` is a violation. |
 | **E** | Estimable | The `### In Scope`, `### Acceptance Criteria`, and `### What` sections together contain enough detail for a developer to form a complexity estimate. `UNKNOWN`, `NEEDS CLARIFICATION`, or `_No response_` in any required section is a violation. |
-| **S** | Small | The item can be delivered in a single iteration. Signs it is too large: more than ~5 acceptance criteria, criteria that imply multiple independent deliverables, or an `effort:XL` label with no split plan noted. |
+| **S** | Small | The item can be delivered in a single iteration. Signs it is too large: more than ~5 acceptance criteria, or criteria that imply multiple independent deliverables. |
 | **T** | Testable | Each criterion in `### Acceptance Criteria` must be objectively verifiable by a third party. Vague criteria ("works correctly", "improves performance", "is better") are violations. |
 
 ---

--- a/agents/label-classifier.md
+++ b/agents/label-classifier.md
@@ -1,0 +1,116 @@
+---
+name: label-classifier
+model: haiku
+effort: low
+disallowedTools: Write, Edit
+description: Assigns type:*, priority:*, effort:* labels to a backlog item, each with one-line reasoning. Returns 'unclear' per group when classification is ambiguous.
+---
+
+# label-classifier
+
+You are a stateless label classifier. Your sole job is to assign exactly one `type:*`, one `priority:*`, and one `effort:*` label to a backlog item and return a structured per-group verdict.
+
+You do NOT create, edit, or delete any files or issues. You only read the input provided and return a verdict.
+
+---
+
+## Input Contract
+
+You receive one or more of the following:
+
+- **Issue title** (required) — the concise title of the backlog item
+- **Issue body** (required) — the full markdown body of the backlog item, expected to contain sections: `### What`, `### Why`, `### In Scope`, `### Out of Scope`, `### Acceptance Criteria`, `### INVEST Notes`
+- **Existing labels** (optional) — any labels already applied (e.g. `type:feature`, `priority:P1`, `effort:M`); treat as context, not as a constraint
+
+---
+
+## Classification Rubric
+
+### Type Labels
+
+Assign exactly ONE of the following. `type:external-blocker` is reserved for infrastructure stubs — NEVER assign it to a work item.
+
+| Label | When to apply |
+| ----- | ------------- |
+| `type:feature` | New capability or user-visible behaviour that does not currently exist |
+| `type:bug` | Incorrect behaviour that deviates from a documented or clearly expected contract |
+| `type:security` | Vulnerability, auth/authz gap, data-exposure risk, or compliance-driven hardening |
+| `type:performance` | Latency, throughput, memory, or resource-efficiency improvement |
+| `type:dx` | Developer-experience improvement: tooling, docs, onboarding, local setup, CI speed |
+| `type:tech-debt` | Internal restructuring with no user-visible behaviour change; reduces future cost |
+| `type:reliability` | Uptime, error recovery, observability, or graceful-degradation improvement |
+| `type:compliance` | Regulatory, legal, or contractual obligation |
+| `type:spike` | Time-boxed research or proof-of-concept to reduce uncertainty |
+
+If the item fits more than one type, choose the dominant one — the label that best captures the primary deliverable.
+
+If no single type clearly dominates, return `unclear: type — <reason>` instead of guessing.
+
+### Priority Labels
+
+| Label | Severity definition |
+| ----- | ------------------- |
+| `priority:P0` | Critical — system broken, security breach, data loss, or no viable workaround exists |
+| `priority:P1` | High — major user or business impact; needs to be addressed in the near term |
+| `priority:P2` | Medium — planned work; important but not blocking anything critical |
+| `priority:P3` | Low — optional, nice-to-have, or easily deferred without consequence |
+
+If the `### Why` section is absent or too vague to judge impact, return `unclear: priority — <reason>`.
+
+### Effort Labels
+
+Effort measures **implementation complexity**, NOT time. Apply the label that best matches the scope of change:
+
+| Label | Complexity |
+| ----- | ---------- |
+| `effort:XS` | Trivial change — a config tweak, a one-liner fix, or a documentation edit |
+| `effort:S` | Small — a focused change within a single file or component, well-understood scope |
+| `effort:M` | Medium — touches multiple files or components; requires some design thought |
+| `effort:L` | Large — significant cross-cutting change; multiple subsystems or substantial design work |
+| `effort:XL` | Extra-large — a major undertaking that probably needs a split plan |
+
+If scope is unknown or the `### In Scope` / `### Acceptance Criteria` sections contain `UNKNOWN` or `NEEDS CLARIFICATION`, return `unclear: effort — <reason>`.
+
+---
+
+## Output Schema
+
+Return EXACTLY this structure — no prose before or after:
+
+```
+type:<x> — <one-line reasoning>
+priority:<y> — <one-line reasoning>
+effort:<z> — <one-line reasoning>
+```
+
+If classification is ambiguous for one or more groups, replace that line with:
+
+```
+unclear: <group> — <one-line reason>
+```
+
+**Examples:**
+
+```
+type:feature — adds OAuth login, a capability not currently in scope
+priority:P1 — blocks user onboarding; no workaround
+effort:M — touches auth middleware and two UI screens
+```
+
+```
+type:tech-debt — no user-visible change; only restructures internal module boundaries
+unclear: priority — ### Why is empty; cannot judge business impact
+effort:S — confined to a single package
+```
+
+---
+
+## Rules & Constraints
+
+- Return ONLY the structured output — no explanation headers, no summaries, no preamble
+- NEVER assign `type:external-blocker` to a work item — if the item is an infrastructure stub, return `unclear: type — item appears to be an external blocker stub; use /add-external-blocker instead`
+- Do NOT suggest fixes to the issue body
+- Do NOT fetch any external data — evaluate only what is provided
+- Do NOT write or edit any files
+- If both the title and body are missing or empty: return all three lines as `unclear: <group> — no input provided`
+- Effort is NEVER measured in time (no hours/days)

--- a/commands/add-backlog-item.md
+++ b/commands/add-backlog-item.md
@@ -33,7 +33,7 @@ Before any item work, verify the repository is provisioned:
   - Desired outcome
   - User/business impact
   - Constraints, risks, and edge cases
-- Ask about relationships to existing items (used in step 9):
+- Ask about relationships to existing items (used in step 8):
   - **Blocked by**: Is this item blocked by any open issue that must be done first? (provide issue numbers; cross-Project blockers are allowed — e.g. an infra issue tracked elsewhere)
   - **Blocking**: Does this item block any open issue? (issue numbers, optional)
   - **Sub-issue parent**: Is this a sub-task of a parent issue / epic? (issue number, optional — sub-issues stay independent: they do NOT inherit the parent's milestone, priority, or rank)
@@ -42,26 +42,7 @@ Before any item work, verify the repository is provisioned:
 
 ---
 
-### 2. Classification
-
-Delegate classification to the `label-classifier` agent:
-
-- **Input**: the issue title and all context gathered in step 1
-- The agent returns a verdict for each of the three label groups (`type:*`, `priority:*`, `effort:*`) with one-line reasoning
-
-Handle the returned verdict:
-
-- `type:*` — if the agent returns `unclear: type`, STOP and ask the user for clarification before proceeding
-- `priority:*` — if the agent returns `unclear: priority`, present the reasoning and ask the user to decide; default to `priority:P2` only if the user explicitly accepts
-- `effort:*` — if the agent returns `unclear: effort`, present the reasoning and ask the user to resolve before proceeding
-
-`type:external-blocker` is reserved for infrastructure stubs created by `/add-external-blocker` — DO NOT classify work items with this type; if the agent returns it or the user attempts to, STOP and redirect them to `/add-external-blocker`.
-
-Carry the `label-classifier` verdict forward to step 5 for label application.
-
----
-
-### 3. Definition (STRICT)
+### 2. Definition (STRICT)
 
 Delegate body authoring to the `issue-body-author` agent:
 
@@ -70,7 +51,7 @@ Delegate body authoring to the `issue-body-author` agent:
 
 The agent returns a fully structured body with canonical sections in strict order: `### What` → `### Why` → `### In Scope` → `### Out of Scope` → `### Acceptance Criteria` → `### INVEST Notes`.
 
-If the agent marks any section with `<!-- TODO: ... -->`, STOP and resolve those gaps with the user before proceeding to step 4.
+If the agent marks any section with `<!-- TODO: ... -->`, STOP and resolve those gaps with the user before proceeding to step 3.
 
 Issue title: concise and descriptive.
 
@@ -82,28 +63,39 @@ Type, Priority, and Effort are NOT in the body — they are applied as repositor
 
 ---
 
-### 4. INVEST Enforcement (MANDATORY)
+### 3. INVEST Enforcement (MANDATORY)
 
-Delegate to the `invest-gate` agent with the body constructed in step 3 and the issue title.
+Delegate to the `invest-gate` agent with the body constructed in step 2 and the issue title.
 
 If `invest-gate` returns `Overall: FAIL`:
 
 - STOP
 - Show the per-letter verdict to the user
 - For any `FAIL` letter, propose a corrected version of the relevant section
-- Do NOT proceed to step 5 until the user approves corrections and `invest-gate` returns `Overall: PASS`
+- Do NOT proceed to step 4 until the user approves corrections and `invest-gate` returns `Overall: PASS`
 
 ---
 
-### 5. Label Application
+### 4. Classification + Label Application
 
-Apply the `type:*`, `priority:*`, and `effort:*` labels returned by `label-classifier` in step 2 (they will be passed as `--label` flags when creating the issue in step 7).
+Delegate classification to the `label-classifier` agent:
 
-The priority label classifies severity for filtering and reporting. It does NOT determine which item is executed next — execution order is set by position on the Project board (see step 8 below). Severity and rank are tracked independently but should be **kept consistent** by this command's relative analysis: a `priority:P0` item should generally land near the top of the Todo column, a `priority:P3` near the bottom, unless the user explicitly justifies a divergence.
+- **Input**: the issue title and the body produced in step 2
+- The agent returns a verdict for each of the three label groups (`type:*`, `priority:*`, `effort:*`) with one-line reasoning
+
+Handle the returned verdict:
+
+- `type:*` — if the agent returns `unclear: type`, STOP and ask the user for clarification before proceeding
+- `priority:*` — if the agent returns `unclear: priority`, present the reasoning and ask the user to decide; default to `priority:P2` only if the user explicitly accepts
+- `effort:*` — if the agent returns `unclear: effort`, present the reasoning and ask the user to resolve before proceeding
+
+`type:external-blocker` is reserved for infrastructure stubs created by `/add-external-blocker` — DO NOT classify work items with this type; if the agent returns it or the user attempts to, STOP and redirect them to `/add-external-blocker`.
+
+These labels will be passed as `--label` flags when creating the issue in step 6.
 
 ---
 
-### 6. Validation
+### 5. Validation
 
 Ensure:
 
@@ -117,7 +109,7 @@ If too vague → request clarification
 
 ---
 
-### 7. Issue Creation (MANDATORY)
+### 6. Issue Creation (MANDATORY)
 
 After validation passes:
 
@@ -128,7 +120,7 @@ After validation passes:
 
 ---
 
-### 8. Project Assignment & Execution Rank (MANDATORY, RELATIVE)
+### 7. Project Assignment & Execution Rank (MANDATORY, RELATIVE)
 
 Add the issue to the linked Project and set its initial Status:
 
@@ -141,13 +133,15 @@ Add the issue to the linked Project and set its initial Status:
 
 This command is responsible for placing the new item at the appropriate rank by RELATIVE analysis against existing Todo items, NOT defaulting to bottom-of-column.
 
-#### 8a. Fetch the current rank order
+The priority label classifies severity for filtering and reporting. It does NOT determine which item is executed next — execution order is set by position on the Project board. Severity and rank are tracked independently but should be **kept consistent** by this command's relative analysis: a `priority:P0` item should generally land near the top of the Todo column, a `priority:P3` near the bottom, unless the user explicitly justifies a divergence.
+
+#### 7a. Fetch the current rank order
 
 - `gh project item-list <project-number> --owner <owner> --query "is:issue status:Todo" --format json --limit 200`
 - The response order is the current rank (top first).
 - For each Todo item, capture its title, `priority:*` label, and any milestone — these are the comparison set.
 
-#### 8b. Determine the new item's rank by relative analysis
+#### 7b. Determine the new item's rank by relative analysis
 
 Compare the new item against each existing Todo item based on:
 
@@ -156,7 +150,7 @@ Compare the new item against each existing Todo item based on:
 - Urgency
 - Frequency
 - Dependencies (does this item block or depend on others?)
-- Consistency with the priority label set in step 5 (a `priority:P0` item should generally rank above all non-P0 items; flag any divergence for user confirmation)
+- Consistency with the priority label set in step 4 (a `priority:P0` item should generally rank above all non-P0 items; flag any divergence for user confirmation)
 
 Propose a concrete rank position:
 
@@ -165,11 +159,11 @@ Propose a concrete rank position:
 - Below a specific existing item
 - Bottom (only if genuinely lowest among current Todos)
 
-#### 8c. Surface re-rank suggestions for existing items
+#### 7c. Surface re-rank suggestions for existing items
 
 If the analysis reveals existing items that appear misranked relative to the new item OR relative to each other (e.g. a `priority:P3` sitting above a `priority:P1`), list each suggested move with rationale. DO NOT apply them silently.
 
-#### 8d. Apply rank changes (USER-CONFIRMED ONLY)
+#### 7d. Apply rank changes (USER-CONFIRMED ONLY)
 
 After the user confirms the proposed positions:
 
@@ -195,7 +189,7 @@ The command MUST NOT apply rank changes without explicit confirmation. Always pr
 
 ---
 
-### 9. Dependencies & Sub-issue Linkage
+### 8. Dependencies & Sub-issue Linkage
 
 Apply the relationships gathered in step 1 (Discovery). All linkages use GitHub's native APIs — they are NOT mirrored in the issue body.
 
@@ -249,7 +243,7 @@ Print the resolved relationships so the user can confirm before continuing to mi
 
 ---
 
-### 10. Milestone Assignment (OPTIONAL, RECOMMENDED)
+### 9. Milestone Assignment (OPTIONAL, RECOMMENDED)
 
 The active milestone is determined as follows:
 
@@ -267,7 +261,7 @@ If no active milestone exists, suggest the user run `/plan-release` after.
 
 ---
 
-### 11. Output
+### 10. Output
 
 Print:
 

--- a/commands/add-backlog-item.md
+++ b/commands/add-backlog-item.md
@@ -44,18 +44,20 @@ Before any item work, verify the repository is provisioned:
 
 ### 2. Classification
 
-- Assign the item to exactly ONE type:
-  - Feature (`type:feature`)
-  - Bug (`type:bug`)
-  - Security (`type:security`)
-  - Performance & Scalability (`type:performance`)
-  - Developer Experience (`type:dx`)
-  - Tech Debt (`type:tech-debt`)
-  - Reliability (`type:reliability`)
-  - Compliance (`type:compliance`)
-  - Spike (`type:spike`)
-- `type:external-blocker` is reserved for infrastructure stubs created by `/add-external-blocker` — DO NOT classify work items with this type; if the user attempts to, STOP and redirect them to `/add-external-blocker`
-- If classification is unclear → STOP and ask for clarification
+Delegate classification to the `label-classifier` agent:
+
+- **Input**: the issue title and all context gathered in step 1
+- The agent returns a verdict for each of the three label groups (`type:*`, `priority:*`, `effort:*`) with one-line reasoning
+
+Handle the returned verdict:
+
+- `type:*` — if the agent returns `unclear: type`, STOP and ask the user for clarification before proceeding
+- `priority:*` — if the agent returns `unclear: priority`, present the reasoning and ask the user to decide; default to `priority:P2` only if the user explicitly accepts
+- `effort:*` — if the agent returns `unclear: effort`, present the reasoning and ask the user to resolve before proceeding
+
+`type:external-blocker` is reserved for infrastructure stubs created by `/add-external-blocker` — DO NOT classify work items with this type; if the agent returns it or the user attempts to, STOP and redirect them to `/add-external-blocker`.
+
+Carry the `label-classifier` verdict forward to step 5 for label application.
 
 ---
 
@@ -93,14 +95,9 @@ If `invest-gate` returns `Overall: FAIL`:
 
 ---
 
-### 5. Priority Classification
+### 5. Label Application
 
-Apply exactly one `priority:*` label that reflects intrinsic severity:
-
-- `priority:P0` — Critical: system broken, security risk, no workaround
-- `priority:P1` — High: major impact, should be addressed soon
-- `priority:P2` — Medium: planned work
-- `priority:P3` — Low: optional or nice-to-have
+Apply the `type:*`, `priority:*`, and `effort:*` labels returned by `label-classifier` in step 2 (they will be passed as `--label` flags when creating the issue in step 7).
 
 The priority label classifies severity for filtering and reporting. It does NOT determine which item is executed next — execution order is set by position on the Project board (see step 8 below). Severity and rank are tracked independently but should be **kept consistent** by this command's relative analysis: a `priority:P0` item should generally land near the top of the Todo column, a `priority:P3` near the bottom, unless the user explicitly justifies a divergence.
 
@@ -300,15 +297,6 @@ Print:
 - Dependencies and sub-issue parent are NOT mirrored in the issue body — GitHub's native API is the only source of truth for these relationships
 - Cross-Project / cross-repo blockers ARE permitted but will be flagged as a smell by `validate-backlog`
 - Sub-issues stay independent — assigning a parent does NOT inherit the parent's milestone, priority, effort, type, or Project rank
-
----
-
-## Priority Reference
-
-- P0 — Critical: system broken, security risk, no workaround
-- P1 — High: major impact, should be addressed soon
-- P2 — Medium: planned work
-- P3 — Low: optional or nice-to-have
 
 ---
 

--- a/commands/migrate-backlog.md
+++ b/commands/migrate-backlog.md
@@ -188,10 +188,10 @@ For each non-Done item, in priority order (P0 → P3):
 3. Capture the returned issue URL and number
 4. Add to the Project:
    - `gh project item-add <project-number> --owner <owner> --url <issue-url>`
-5. Set the Project `Status` field to the mapped value (`Todo` or `In Progress` only — Done items were skipped in 9a):
+5. Set the Project `Status` field to the mapped value (`Todo` or `In Progress` only — Done items were skipped in 8a):
    - Resolve field/option IDs via `gh project field-list <project-number> --owner <owner> --format json`
    - `gh project item-edit --id <item-id> --project-id <project-id> --field-id <status-field-id> --single-select-option-id <option-id>`
-6. If the user confirmed milestone assignment in 9b:
+6. If the user confirmed milestone assignment in 8b:
    - `gh issue edit <n> --milestone <milestone-number>`
 
 #### 8d. Build the source-title → issue-id lookup
@@ -201,18 +201,18 @@ After all issues are created, build a mapping from source title (and any explici
 - For each created issue, capture `id` from the `gh issue create` response (or via `gh api "repos/<o>/<r>/issues/<n>" --jq '.id'`)
 - Skipped Done items are NOT in this map (they have no GitHub issue)
 
-This map is used in 9e to resolve dependency hints to concrete issue IDs.
+This map is used in 8e to resolve dependency hints to concrete issue IDs.
 
 #### 8e. Propose and apply dependencies (USER-CONFIRMED)
 
 1. **Delegate to `dependency-inferrer`.** Call the `dependency-inferrer` agent with:
    - **Prose**: the full source text of each migrated item (from Step 1 parsing), one entry per item labeled with its source title
-   - **Issue roster**: the source-title → issue-number map from Step 9d, formatted as `#<num> "<title>"` per line
+   - **Issue roster**: the source-title → issue-number map from Step 8d, formatted as `#<num> "<title>"` per line
    If the agent returns `CANDIDATES: none`, skip the rest of this step.
 
-2. **Resolve each candidate against the source-title → issue-id map** (from Step 9d):
+2. **Resolve each candidate against the source-title → issue-id map** (from Step 8d):
    - `UNRESOLVED` targets: surface as "manual resolution needed" in the Migration Report — DO NOT guess
-   - Candidates pointing at a Done item (skipped in 9a): skip the candidate and note it in the Migration Report
+   - Candidates pointing at a Done item (skipped in 8a): skip the candidate and note it in the Migration Report
 
 3. **Present all candidates to the user in a single review block** (NOT one-by-one) so they can scan and confirm in bulk. Format:
 

--- a/commands/migrate-backlog.md
+++ b/commands/migrate-backlog.md
@@ -54,7 +54,6 @@ If item boundaries are unclear:
 For EACH item, derive the GitHub-native representation:
 
 - **Title** — concise; will be issue title
-- **Labels** — delegate classification to the `label-classifier` agent using the item's normalized title and body draft; the agent returns a verdict for `type:*`, `priority:*`, and `effort:*` — use these results in steps 4 and 5; never `type:external-blocker` — stubs are infrastructure and are never migrated from backlog files
 - **Body** — delegate body authoring to the `issue-body-author` agent:
   - **Mode**: `migrate`
   - **Input**: the source prose for this item (as parsed in step 1)
@@ -62,7 +61,7 @@ For EACH item, derive the GitHub-native representation:
 - **Status mapping** (Project field):
   - Source `Todo` (or unspecified) → Project `Todo`
   - Source `In Progress` → Project `In Progress`
-  - Source `Done` / `Completed` / shipped items → **SKIPPED** (see step 9). Done items are historical and are NOT migrated to GitHub.
+  - Source `Done` / `Completed` / shipped items → **SKIPPED** (see step 8). Done items are historical and are NOT migrated to GitHub.
 
 ---
 
@@ -82,24 +81,7 @@ Additionally:
 
 ---
 
-### 4. Classification
-
-Apply the `type:*` verdict from the `label-classifier` agent called in step 2:
-
-- If `unclear: type` was returned, note the ambiguity in `### INVEST Notes` and apply the `needs-clarification` label
-
----
-
-### 5. Prioritization (RELATIVE)
-
-Apply the `priority:*` and `effort:*` verdicts from the `label-classifier` agent called in step 2:
-
-- If `unclear: priority` was returned, default to `priority:P2`, add `Priority needs validation` to `### INVEST Notes`, and apply the `needs-clarification` label
-- If `unclear: effort` was returned, add an effort question to `### INVEST Notes` and apply the `needs-clarification` label
-
----
-
-### 6. INVEST Evaluation
+### 4. INVEST Evaluation
 
 For each item, delegate to the `invest-gate` agent with the normalized body and title.
 
@@ -111,7 +93,24 @@ If `invest-gate` returns `Overall: FAIL`:
 
 ---
 
-### 7. Deduplication & Structuring
+### 5. Label Application
+
+Delegate classification to the `label-classifier` agent:
+
+- **Input**: the normalized title and the body finalized in steps 3–4
+- The agent returns a verdict for each of the three label groups (`type:*`, `priority:*`, `effort:*`) with one-line reasoning
+
+Apply the returned verdicts:
+
+- `type:*` — if `unclear: type` was returned, note the ambiguity in `### INVEST Notes` and apply the `needs-clarification` label
+- `priority:*` — if `unclear: priority` was returned, default to `priority:P2`, add `Priority needs validation` to `### INVEST Notes`, and apply the `needs-clarification` label
+- `effort:*` — if `unclear: effort` was returned, add an effort question to `### INVEST Notes` and apply the `needs-clarification` label
+
+Never assign `type:external-blocker` — stubs are infrastructure and are never migrated from backlog files.
+
+---
+
+### 6. Deduplication & Structuring
 
 - Detect duplicates or overlaps across the source backlog
 - DO NOT auto-merge or auto-split
@@ -119,7 +118,7 @@ If `invest-gate` returns `Overall: FAIL`:
 
 ---
 
-### 8. VALIDATION STEP (HARD GATE)
+### 7. VALIDATION STEP (HARD GATE)
 
 Before any issue is created, verify:
 
@@ -138,9 +137,9 @@ If any check fails:
 
 ---
 
-### 9. Migration Execution
+### 8. Migration Execution
 
-#### 9a. Filter out Done items
+#### 8a. Filter out Done items
 
 Before any GitHub mutation, partition the validated items:
 
@@ -149,7 +148,7 @@ Before any GitHub mutation, partition the validated items:
 
 Done items are historical and would only clutter the Project. Their PR shipped references stay in the original BACKLOG.md as a record.
 
-#### 9b. Resolve active milestone
+#### 8b. Resolve active milestone
 
 - `gh api "repos/<owner>/<repo>/milestones?state=open&per_page=100"`
 - Primary sort: `due_on` ascending (milestones without a `due_on` are sorted last)
@@ -158,7 +157,7 @@ Done items are historical and would only clutter the Project. Their PR shipped r
 - If an active milestone is found, ask the user once (before any issue is created) whether to assign all migrated items to it. Record the answer — it applies to all items uniformly.
 - If no active milestone exists, skip milestone assignment entirely and note it in the Migration Report.
 
-#### 9c. Create issues
+#### 8c. Create issues
 
 For each non-Done item, in priority order (P0 → P3):
 
@@ -195,7 +194,7 @@ For each non-Done item, in priority order (P0 → P3):
 6. If the user confirmed milestone assignment in 9b:
    - `gh issue edit <n> --milestone <milestone-number>`
 
-#### 9d. Build the source-title → issue-id lookup
+#### 8d. Build the source-title → issue-id lookup
 
 After all issues are created, build a mapping from source title (and any explicit identifiers used in the source) to the new issue's numeric `id` (database ID, not number):
 
@@ -204,7 +203,7 @@ After all issues are created, build a mapping from source title (and any explici
 
 This map is used in 9e to resolve dependency hints to concrete issue IDs.
 
-#### 9e. Propose and apply dependencies (USER-CONFIRMED)
+#### 8e. Propose and apply dependencies (USER-CONFIRMED)
 
 1. **Delegate to `dependency-inferrer`.** Call the `dependency-inferrer` agent with:
    - **Prose**: the full source text of each migrated item (from Step 1 parsing), one entry per item labeled with its source title
@@ -234,7 +233,7 @@ If the Dependencies API is unavailable on this repo (private repo without paid p
 
 ---
 
-### 10. Migration Report (MANDATORY)
+### 9. Migration Report (MANDATORY)
 
 After all items are processed, output a Migration Report containing:
 

--- a/commands/migrate-backlog.md
+++ b/commands/migrate-backlog.md
@@ -54,9 +54,7 @@ If item boundaries are unclear:
 For EACH item, derive the GitHub-native representation:
 
 - **Title** — concise; will be issue title
-- **Type** — exactly one type label (`type:feature`, `type:bug`, `type:security`, `type:performance`, `type:dx`, `type:tech-debt`, `type:reliability`, `type:compliance`, `type:spike`); never `type:external-blocker` — stubs are infrastructure and are never migrated from backlog files
-- **Priority** — exactly one priority label (`priority:P0` / `priority:P1` / `priority:P2` / `priority:P3`)
-- **Effort** — exactly one effort label (`effort:XS` / `effort:S` / `effort:M` / `effort:L` / `effort:XL`) — complexity-based, NOT time
+- **Labels** — delegate classification to the `label-classifier` agent using the item's normalized title and body draft; the agent returns a verdict for `type:*`, `priority:*`, and `effort:*` — use these results in steps 4 and 5; never `type:external-blocker` — stubs are infrastructure and are never migrated from backlog files
 - **Body** — delegate body authoring to the `issue-body-author` agent:
   - **Mode**: `migrate`
   - **Input**: the source prose for this item (as parsed in step 1)
@@ -86,25 +84,18 @@ Additionally:
 
 ### 4. Classification
 
-- Assign exactly ONE type
-- If ambiguous:
-  - Choose best fit
-  - Note the justification in `### INVEST Notes`
+Apply the `type:*` verdict from the `label-classifier` agent called in step 2:
+
+- If `unclear: type` was returned, note the ambiguity in `### INVEST Notes` and apply the `needs-clarification` label
 
 ---
 
 ### 5. Prioritization (RELATIVE)
 
-- Infer based on:
-  - Urgency language
-  - Impact
-  - Risk
+Apply the `priority:*` and `effort:*` verdicts from the `label-classifier` agent called in step 2:
 
-If unclear:
-
-- Default to `priority:P2`
-- Add `Priority needs validation` to `### INVEST Notes`
-- Apply `needs-clarification` label
+- If `unclear: priority` was returned, default to `priority:P2`, add `Priority needs validation` to `### INVEST Notes`, and apply the `needs-clarification` label
+- If `unclear: effort` was returned, add an effort question to `### INVEST Notes` and apply the `needs-clarification` label
 
 ---
 

--- a/commands/refine-backlog-item.md
+++ b/commands/refine-backlog-item.md
@@ -134,20 +134,22 @@ If INVEST passes (or partial — per step 5):
 
 ### 7. Re-evaluate Labels (RELATIVE)
 
-Refinement frequently reveals different severity, effort, or type than `migrate-backlog` inferred. Re-run the same relative analysis used by `add-backlog-item` step 5:
+Refinement frequently reveals different severity, effort, or type than `migrate-backlog` inferred. Delegate re-classification to the `label-classifier` agent:
 
-- Fetch open Project items with their labels: `gh issue list --state open --json number,title,labels --limit 200`
-- Compare the refined item against existing items based on:
-  - Impact
-  - Risk
-  - Urgency
-  - Frequency
-- Propose changes (independently for each label group):
-  - `priority:*` (severity classification)
-  - `effort:*` (complexity, NOT time)
-  - `type:*` (if classification is now clearer)
-- Apply changes ONLY after explicit user confirmation:
-  - `gh issue edit <n> --remove-label <old> --add-label <new>`
+- **Input**: the refined issue title and the reconstructed body from step 4
+- The agent returns a verdict for each of the three label groups (`type:*`, `priority:*`, `effort:*`) with one-line reasoning
+
+Compare the agent's verdict against the currently applied labels and propose changes (independently for each group):
+
+- `priority:*` (severity classification)
+- `effort:*` (complexity, NOT time)
+- `type:*` (if classification is now clearer)
+
+If the agent returns `unclear` for a group, surface the reasoning and ask the user to decide.
+
+Apply changes ONLY after explicit user confirmation:
+
+- `gh issue edit <n> --remove-label <old> --add-label <new>`
 
 If existing items appear misranked in their priority labels relative to the refined item, surface the discrepancy and recommend label changes for those existing items. Apply ONLY after confirmation.
 


### PR DESCRIPTION
## Summary

- Add `agents/label-classifier.md` — a stateless Haiku agent that assigns `type:*`, `priority:*`, and `effort:*` labels with one-line reasoning per group, returning `unclear` rather than guessing and refusing to emit `type:external-blocker` for work items
- Remove all inline label-classification rubrics from `add-backlog-item`, `migrate-backlog`, and `refine-backlog-item`, delegating to the new agent instead
- Reorder classification in `add-backlog-item` and `migrate-backlog` so `label-classifier` always receives the fully structured, INVEST-corrected body — not raw user context or a draft with unresolved TODO comments
- Collapse `migrate-backlog` steps 4 (Classification) and 5 (Prioritization) into a single **Label Application** step; move INVEST to run before it, matching `add-backlog-item` behavior
- Remove the unreachable `effort:XL` clause from `invest-gate`'s S criterion (no caller passes labels; the check also creates a circular dependency since effort is derived from the body invest-gate validates)

## Step order rationale

`label-classifier` accuracy depends on the structured body sections (`### Why` for priority, `### In Scope` / `### Acceptance Criteria` for effort). In both commands, classification now runs after:

1. `issue-body-author` has drafted the canonical body
2. `invest-gate` has enforced INVEST (in `add-backlog-item`: interactively corrects gaps; in `migrate-backlog`: converts `<!-- TODO -->` comments to `UNKNOWN`/`NEEDS CLARIFICATION` markers that the classifier explicitly checks)

`refine-backlog-item` was already sequenced correctly (INVEST Gate → label re-evaluation) and required no changes.

## Acceptance Criteria mapping

| AC | Satisfied by |
|----|-------------|
| `agents/label-classifier.md` exists with the specified frontmatter | New file with `name`, `model: haiku`, `effort: low`, `disallowedTools: Write, Edit`, `description` |
| All three caller commands delegate to `label-classifier` and contain no inline rubric | Steps updated in `add-backlog-item`, `migrate-backlog`, `refine-backlog-item` |
| Output schema documented in agent body and consistent across callers | `type:<x> — <reasoning>` / `priority:<y> — <reasoning>` / `effort:<z> — <reasoning>` schema in agent; callers reference it uniformly |
| Agent refuses to emit `type:external-blocker`; signals `unclear` instead | Explicit rule in agent's Rules & Constraints and Type Labels table |
| `label-classifier` receives the final body in all callers | Sequenced after body authoring + INVEST in both `add-backlog-item` and `migrate-backlog` |
| CLAUDE.md consistency greps still pass | All six greps verified: 10 type labels, 4 priority labels, 5 effort labels, identical preflight stop string, metadata file refs, zero bucket occurrences |

Closes #94
Refs #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)