### PR TITLE
refactor: extract rank-recommender subagent

### DIFF
--- a/agents/rank-recommender.md
+++ b/agents/rank-recommender.md
@@ -21,12 +21,16 @@ You receive:
 - **Candidate item** (required):
   - `title` — the concise issue title
   - `what` — one-line summary from the `### What` section
+  - `type` — the assigned `type:*` label
   - `priority` — the assigned `priority:*` label (P0–P3)
+  - `effort` — the assigned `effort:*` label (XS–XL)
 
 - **Current Todo column** (required):
   - Ordered list (top-to-bottom = highest to lowest execution priority) of existing items, each with:
     - `title` — the issue title
+    - `type` — the `type:*` label
     - `priority` — the `priority:*` label
+    - `effort` — the `effort:*` label
 
 ---
 
@@ -90,8 +94,8 @@ Use the **exact** title of the neighboring item as written in the input — do n
 - Return ONLY the structured output — no headers, no preamble, no summaries
 - If the Todo column is empty, always return `position: top`
 - If the candidate is a `priority:P0` item, it should rank above all non-P0 items unless a dependency prevents it — in that case, emit a `divergence_flag`
-- Do NOT consider milestone, effort, or type labels in ranking decisions — only priority, title, what summary, and the five dimensions
+- Do NOT consider milestone in ranking decisions
 - Do NOT fetch any external data — evaluate only what is provided
 - Do NOT write or edit any files
 - Each rationale line must be one sentence; do not use bullet points within rationale lines
-- If input is missing `what` for the candidate, evaluate using only title and priority
+- If input is missing `what` for the candidate, evaluate using only title and labels

--- a/agents/rank-recommender.md
+++ b/agents/rank-recommender.md
@@ -1,0 +1,97 @@
+---
+name: rank-recommender
+model: sonnet
+effort: medium
+disallowedTools: Write, Edit
+description: Recommends where a candidate backlog item should sit in the Project's Todo column. Returns a concrete position, per-dimension rationale, and a flag when the recommended rank diverges from what the priority label would imply.
+---
+
+# rank-recommender
+
+You are a stateless rank analyst. Your sole job is to recommend where a candidate backlog item should be positioned within an existing Todo column, based on relative analysis across five dimensions.
+
+You do NOT create, edit, or delete any files or issues. You only read the input provided and return a recommendation.
+
+---
+
+## Input Contract
+
+You receive:
+
+- **Candidate item** (required):
+  - `title` — the concise issue title
+  - `what` — one-line summary from the `### What` section
+  - `priority` — the assigned `priority:*` label (P0–P3)
+
+- **Current Todo column** (required):
+  - Ordered list (top-to-bottom = highest to lowest execution priority) of existing items, each with:
+    - `title` — the issue title
+    - `priority` — the `priority:*` label
+
+---
+
+## Ranking Rubric
+
+Evaluate the candidate against each existing item on five dimensions. Higher score on any dimension means the candidate should rank higher (earlier in execution order).
+
+### Dimensions
+
+| Dimension | Question to answer |
+| --------- | ------------------ |
+| **Impact** | How significant is the user/business impact if this item is NOT delivered soon? P0 = production-breaking / data-loss; P1 = major user-facing blocker; P2 = noticeable but workable; P3 = optional improvement. |
+| **Risk** | How much does delay increase system risk, compound other problems, or narrow the solution space? |
+| **Urgency** | Is there a time-sensitive external constraint, deadline, or commitment tied to this item? Urgency is independent of impact — a low-impact item can be urgent if a release gate depends on it. |
+| **Frequency** | How often does the gap this item addresses affect users or the system? Higher frequency = higher rank. |
+| **Dependencies** | Does this item unblock other Todo items? If so, it should rank above those items. Does it depend on other Todo items? If so, it should rank below those items. |
+
+### Priority-rank consistency
+
+The `priority:*` label encodes severity classification. Execution rank should be **consistent** with priority unless a dimension justifies a divergence:
+
+- A `priority:P0` candidate should generally sit above all non-P0 items in the Todo column.
+- A `priority:P1` candidate should generally sit above all P2 and P3 items.
+- A `priority:P2` candidate should generally sit above all P3 items.
+- A `priority:P3` candidate should generally sit below all higher-priority items.
+
+Emit a `divergence_flag` when the recommended position conflicts with this expected ordering — i.e., a higher-priority candidate is placed below a lower-priority existing item, or a lower-priority candidate is placed above a higher-priority existing item.
+
+---
+
+## Output Schema
+
+Return EXACTLY this structure — no prose before or after:
+
+```
+position: top
+  OR
+position: above: <exact title of existing item>
+  OR
+position: below: <exact title of existing item>
+  OR
+position: bottom
+
+rationale:
+  Impact: <one-line reasoning>
+  Risk: <one-line reasoning>
+  Urgency: <one-line reasoning>
+  Frequency: <one-line reasoning>
+  Dependencies: <one-line reasoning>
+
+divergence_flag: <one-line explanation of the priority/rank conflict>
+  (OMIT this line entirely if there is no divergence)
+```
+
+Use the **exact** title of the neighboring item as written in the input — do not paraphrase.
+
+---
+
+## Rules & Constraints
+
+- Return ONLY the structured output — no headers, no preamble, no summaries
+- If the Todo column is empty, always return `position: top`
+- If the candidate is a `priority:P0` item, it should rank above all non-P0 items unless a dependency prevents it — in that case, emit a `divergence_flag`
+- Do NOT consider milestone, effort, or type labels in ranking decisions — only priority, title, what summary, and the five dimensions
+- Do NOT fetch any external data — evaluate only what is provided
+- Do NOT write or edit any files
+- Each rationale line must be one sentence; do not use bullet points within rationale lines
+- If input is missing `what` for the candidate, evaluate using only title and priority

--- a/commands/add-backlog-item.md
+++ b/commands/add-backlog-item.md
@@ -141,23 +141,18 @@ The priority label classifies severity for filtering and reporting. It does NOT 
 - The response order is the current rank (top first).
 - For each Todo item, capture its title, `priority:*` label, and any milestone — these are the comparison set.
 
-#### 7b. Determine the new item's rank by relative analysis
+#### 7b. Determine the new item's rank by delegating to `rank-recommender`
 
-Compare the new item against each existing Todo item based on:
+Call the `rank-recommender` agent with:
+- **Candidate item**: the issue title, one-line `### What` summary, and the `priority:*` label from step 4
+- **Current Todo column**: the ordered list (top-to-bottom) from step 7a — each item's title and `priority:*` label
 
-- Impact
-- Risk
-- Urgency
-- Frequency
-- Dependencies (does this item block or depend on others?)
-- Consistency with the priority label set in step 4 (a `priority:P0` item should generally rank above all non-P0 items; flag any divergence for user confirmation)
+The agent returns:
+- `position:` — `top` | `above: <item title>` | `below: <item title>` | `bottom`
+- `rationale:` — per-dimension Impact / Risk / Urgency / Frequency / Dependencies
+- `divergence_flag:` (if present) — the agent detected a priority/rank conflict; surface this to the user and ask them to confirm or override
 
-Propose a concrete rank position:
-
-- Top of the column (work next)
-- Above a specific existing item
-- Below a specific existing item
-- Bottom (only if genuinely lowest among current Todos)
+Present the agent's recommendation and rationale to the user before applying any rank change.
 
 #### 7c. Surface re-rank suggestions for existing items
 

--- a/commands/add-backlog-item.md
+++ b/commands/add-backlog-item.md
@@ -144,8 +144,8 @@ The priority label classifies severity for filtering and reporting. It does NOT 
 #### 7b. Determine the new item's rank by delegating to `rank-recommender`
 
 Call the `rank-recommender` agent with:
-- **Candidate item**: the issue title, one-line `### What` summary, and the `priority:*` label from step 4
-- **Current Todo column**: the ordered list (top-to-bottom) from step 7a — each item's title and `priority:*` label
+- **Candidate item**: the issue title, one-line `### What` summary, and the `type:*`, `priority:*`, `effort:*` labels from step 4
+- **Current Todo column**: the ordered list (top-to-bottom) from step 7a — each item's title and `type:*`, `priority:*`, `effort:*` labels
 
 The agent returns:
 - `position:` — `top` | `above: <item title>` | `below: <item title>` | `bottom`

--- a/commands/migrate-backlog.md
+++ b/commands/migrate-backlog.md
@@ -237,18 +237,18 @@ After all issues are created and dependencies are applied, set the execution ord
 
 1. **Fetch the full current Todo column** (existing items plus newly migrated items):
    `gh project item-list <project-number> --owner <owner> --query "is:issue status:Todo" --format json --limit 200`
-   Capture each item's title and `priority:*` label; the response order is the current rank (top first).
+   Capture each item's title and `type:*`, `priority:*`, `effort:*` labels; the response order is the current rank (top first).
 
 2. **Call `rank-recommender` for each migrated item** (one agent call per item, in P0→P3 order) using:
-   - **Candidate item**: the migrated issue title, one-line `### What` summary, and its `priority:*` label
+   - **Candidate item**: the migrated issue title, one-line `### What` summary, and its `type:*`, `priority:*`, `effort:*` labels
    - **Current Todo column**: the ordered list from the most recent `item-list` fetch (update after each confirmed repositioning)
    Collect all recommendations before presenting them to the user.
 
 3. **Present the full proposed ordering** in a single block so the user can review and adjust:
    ```text
    Proposed Todo column order (top → bottom):
-     1. <title> [priority:Px] — rank-recommender: top (existing)
-     2. <title> [priority:Py] — rank-recommender: above "<title>" (migrated)
+     1. <title> [type:bug | priority:P0 | effort:S] — rank-recommender: top (existing)
+     2. <title> [type:feature | priority:P1 | effort:M] — rank-recommender: above "<title>" (migrated)
      ...
    ```
    Do NOT apply any position changes before the user confirms.

--- a/commands/migrate-backlog.md
+++ b/commands/migrate-backlog.md
@@ -231,6 +231,42 @@ NEVER auto-apply. Inferred dependencies have a high false-positive rate — a fa
 
 If the Dependencies API is unavailable on this repo (private repo without paid plan, returns `404`), skip this entire substep and emit one warning line in the Migration Report: `Issue Dependencies API unavailable — dependency inference skipped. Migrated <N> dependency hints retained as proposals only.`
 
+#### 8f. Rank positioning (USER-CONFIRMED)
+
+After all issues are created and dependencies are applied, set the execution order for the migrated items:
+
+1. **Fetch the full current Todo column** (existing items plus newly migrated items):
+   `gh project item-list <project-number> --owner <owner> --query "is:issue status:Todo" --format json --limit 200`
+   Capture each item's title and `priority:*` label; the response order is the current rank (top first).
+
+2. **Call `rank-recommender` for each migrated item** (one agent call per item, in P0→P3 order) using:
+   - **Candidate item**: the migrated issue title, one-line `### What` summary, and its `priority:*` label
+   - **Current Todo column**: the ordered list from the most recent `item-list` fetch (update after each confirmed repositioning)
+   Collect all recommendations before presenting them to the user.
+
+3. **Present the full proposed ordering** in a single block so the user can review and adjust:
+   ```text
+   Proposed Todo column order (top → bottom):
+     1. <title> [priority:Px] — rank-recommender: top (existing)
+     2. <title> [priority:Py] — rank-recommender: above "<title>" (migrated)
+     ...
+   ```
+   Do NOT apply any position changes before the user confirms.
+
+4. **Apply confirmed position changes** via GraphQL `updateProjectV2ItemPosition` mutations:
+   ```graphql
+   mutation {
+     updateProjectV2ItemPosition(input: {
+       projectId: "<project-node-id>",
+       itemId: "<item-node-id>",
+       afterId: "<existing-item-node-id-it-should-follow>"
+     }) {
+       items { totalCount }
+     }
+   }
+   ```
+   Use the `id` fields from the `item-list` response. To place an item at the very top, omit `afterId` (or set it to `null`). Apply positions top-to-bottom to avoid ordering conflicts.
+
 ---
 
 ### 9. Migration Report (MANDATORY)

--- a/commands/refine-backlog-item.md
+++ b/commands/refine-backlog-item.md
@@ -157,18 +157,19 @@ If existing items appear misranked in their priority labels relative to the refi
 
 ### 8. Re-evaluate Project Rank + Dependencies (RELATIVE)
 
-Same logic as `add-backlog-item` step 8 (8a → 8d) + step 9:
-
 - Fetch the current Todo column rank: `gh project item-list <project-number> --owner <owner> --query "is:issue status:Todo" --format json --limit 200`
-- Determine where the refined item should sit by:
-  - Impact
-  - Risk
-  - Urgency
-  - Frequency
-  - Dependencies (does this item block or depend on others?)
-  - Consistency with the (possibly updated) `priority:*` label — flag divergences for user confirmation
-- Propose a concrete rank position (top, above/below specific items, or bottom)
-- If existing items appear misranked relative to the refined item, surface those re-rank suggestions too
+- The response order is the current rank (top first). For each Todo item, capture its title and `priority:*` label.
+
+Delegate rank analysis to the `rank-recommender` agent:
+- **Candidate item**: the refined issue title, one-line `### What` summary, and the current (or updated) `priority:*` label from step 7
+- **Current Todo column**: the ordered list (top-to-bottom) from the `item-list` response — each item's title and `priority:*` label
+
+The agent returns:
+- `position:` — `top` | `above: <item title>` | `below: <item title>` | `bottom`
+- `rationale:` — per-dimension Impact / Risk / Urgency / Frequency / Dependencies
+- `divergence_flag:` (if present) — surface to the user and ask them to confirm or override the divergence
+
+If the analysis reveals existing items that appear misranked relative to the refined item (e.g. a `priority:P3` sitting above a `priority:P1`), list each suggested move with rationale. DO NOT apply them silently.
 
 Apply rank changes ONLY after explicit user confirmation, via:
 

--- a/commands/refine-backlog-item.md
+++ b/commands/refine-backlog-item.md
@@ -158,11 +158,11 @@ If existing items appear misranked in their priority labels relative to the refi
 ### 8. Re-evaluate Project Rank + Dependencies (RELATIVE)
 
 - Fetch the current Todo column rank: `gh project item-list <project-number> --owner <owner> --query "is:issue status:Todo" --format json --limit 200`
-- The response order is the current rank (top first). For each Todo item, capture its title and `priority:*` label.
+- The response order is the current rank (top first). For each Todo item, capture its title and `type:*`, `priority:*`, `effort:*` labels.
 
 Delegate rank analysis to the `rank-recommender` agent:
-- **Candidate item**: the refined issue title, one-line `### What` summary, and the current (or updated) `priority:*` label from step 7
-- **Current Todo column**: the ordered list (top-to-bottom) from the `item-list` response — each item's title and `priority:*` label
+- **Candidate item**: the refined issue title, one-line `### What` summary, and the current (or updated) `type:*`, `priority:*`, `effort:*` labels from step 7
+- **Current Todo column**: the ordered list (top-to-bottom) from the `item-list` response — each item's title and `type:*`, `priority:*`, `effort:*` labels
 
 The agent returns:
 - `position:` — `top` | `above: <item title>` | `below: <item title>` | `bottom`


### PR DESCRIPTION
## Summary

- Add `agents/rank-recommender.md`: stateless agent that recommends where a candidate item should sit in the Project's Todo column, using a 5-dimension rubric (Impact, Risk, Urgency, Frequency, Dependencies) and emitting a `divergence_flag` when the recommended rank conflicts with the `priority:*` label
- Replace the inline rubric in `commands/add-backlog-item.md` step 7b and `commands/refine-backlog-item.md` step 8 with delegation calls to `rank-recommender`
- Add new substep `8f — Rank positioning` to `commands/migrate-backlog.md`: calls `rank-recommender` for each migrated item and presents a full proposed ordering for user confirmation before applying `updateProjectV2ItemPosition` mutations

## Acceptance Criteria

- [x] `agents/rank-recommender.md` exists with valid frontmatter (`name`, `model`, `effort`, `disallowedTools`)
- [x] All three caller commands delegate to `rank-recommender`; no inline 5-dimension rubric remains
- [x] Output schema documented in agent body (`position:`, `rationale:`, `divergence_flag:`) and consistent across callers
- [x] Agent emits `divergence_flag` when recommended rank conflicts with what `priority:*` implies
- [x] Agent never mutates the Project (`disallowedTools: Write, Edit`; body explicitly states read-only)
- [x] CLAUDE.md consistency greps pass (`type:*`, `priority:*`, `effort:*`, preflight stop string, no `bucket` leftovers)

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)