### PR TITLE
fix: use milestone title in gh issue edit/create

### DIFF
--- a/commands/add-backlog-item.md
+++ b/commands/add-backlog-item.md
@@ -249,7 +249,7 @@ The active milestone is determined as follows:
 
 Ask the user whether to assign this item to the active milestone:
 
-- If yes: `gh issue edit <n> --milestone <milestone-number>`
+- If yes: `gh issue edit <n> --milestone "<milestone-title>"`
 - If no: leave unassigned (will be picked up by `execute-backlog-item` only after items in the active milestone are exhausted)
 
 If no active milestone exists, suggest the user run `/plan-release` after.

--- a/commands/migrate-backlog.md
+++ b/commands/migrate-backlog.md
@@ -192,7 +192,7 @@ For each non-Done item, in priority order (P0 → P3):
    - Resolve field/option IDs via `gh project field-list <project-number> --owner <owner> --format json`
    - `gh project item-edit --id <item-id> --project-id <project-id> --field-id <status-field-id> --single-select-option-id <option-id>`
 6. If the user confirmed milestone assignment in 8b:
-   - `gh issue edit <n> --milestone <milestone-number>`
+   - `gh issue edit <n> --milestone "<milestone-title>"`
 
 #### 8d. Build the source-title → issue-id lookup
 

--- a/commands/plan-release.md
+++ b/commands/plan-release.md
@@ -195,7 +195,7 @@ Create the milestone via the GitHub API:
 
 Assign every item in the confirmed scope to the new milestone:
 
-- For each scoped issue: `gh issue edit <n> --milestone <milestone-number>`
+- For each scoped issue: `gh issue edit <n> --milestone "<milestone-title>"`
 - Surface any `gh` errors verbatim; do not silently skip failures.
 
 #### Forward-port prompt (Mode A only)
@@ -331,7 +331,7 @@ options:
     description: "Go back to the selection step."
 ```
 
-Apply additions: `gh issue edit <n> --milestone <milestone-number>` for each confirmed item.
+Apply additions: `gh issue edit <n> --milestone "<milestone-title>"` for each confirmed item.
 Surface any `gh` errors verbatim; do not skip failures silently.
 
 ---
@@ -391,7 +391,7 @@ Apply the disposition:
       # one entry per other open milestone
     ```
 
-  - Apply: `gh issue edit <n> --milestone <target-number>`
+  - Apply: `gh issue edit <n> --milestone "<target-milestone-title>"`
 - **Close as won't fix**:
   - `gh issue comment <n> --body "Closing as won't fix."`
   - `gh issue edit <n> --state closed`


### PR DESCRIPTION
## Summary

- **Root cause:** `gh issue edit --milestone` and `gh issue create --milestone` expect a **title string**, not an integer. Five call sites were passing `<milestone-number>` (an integer ID), causing milestone assignment to silently fail.
- **Fix:** Replace all `<milestone-number>` / `<target-number>` placeholders with the quoted title form (`"<milestone-title>"` / `"<target-milestone-title>"`).

## Manual verification steps

1. Run `/add-backlog-item` → at the milestone assignment prompt, confirm Yes → verify the created issue shows the milestone (e.g. `v0.5.0`) on GitHub.
2. Prepare a small sample `BACKLOG.md`, run `/migrate-backlog` → confirm milestone assignment (when user says yes) works on the created issues.
3. Run `/plan-release` in creation mode → confirm newly scoped issues appear in the milestone after Step 9 assignment.
4. Run `/plan-release <milestone>` in re-planning mode → add an item and confirm it gets the milestone; remove an item and choose "Carry forward" → confirm it moves to the target milestone.

Closes #103