### PR TITLE
fix: use repo-relative path for marketplace plugin source

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "github-backlog-management",
       "description": "GitHub-native backlog automation. Manage Issues + Projects v2 with AI-enforced INVEST quality, dependency tracking, and one-command execution.",
-      "source": "./.claude-plugin/plugin.json",
+      "source": "./",
       "version": "0.4.0",
       "category": "productivity",
       "keywords": ["github", "backlog", "issues", "projects-v2", "milestones", "labels", "invest", "agile", "prioritization"]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,10 +10,7 @@
     {
       "name": "github-backlog-management",
       "description": "GitHub-native backlog automation. Manage Issues + Projects v2 with AI-enforced INVEST quality, dependency tracking, and one-command execution.",
-      "source": {
-        "source": "github",
-        "repo": "gringolito/github-backlog-management-skill"
-      },
+      "source": "./.claude-plugin/plugin.json",
       "version": "0.4.0",
       "category": "productivity",
       "keywords": ["github", "backlog", "issues", "projects-v2", "milestones", "labels", "invest", "agile", "prioritization"]


### PR DESCRIPTION
## Summary

- Changes the `source` field in `.claude-plugin/marketplace.json` from a GitHub remote reference (`{ "source": "github", "repo": "..." }`) to a repo-relative path (`./.claude-plugin/plugin.json`)
- Portable installs across any clone or fork — no hardcoded upstream owner/repo

## Works around anthropics/claude-code#26588

With a GitHub source reference, Claude Code attempts a **second SSH clone** for the plugin repo when installing from the marketplace. This fails for users without SSH keys configured for GitHub. Using a repo-relative path means the `plugin.json` is read from the already-cloned marketplace repo, bypassing the extra clone entirely.

## Test plan

- [ ] CI passes: `claude plugin validate .claude-plugin/marketplace.json`
- [ ] CI passes: `claude plugin validate .claude-plugin/plugin.json`
- [ ] Install via `/plugin marketplace add gringolito` succeeds without SSH keys

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)