### PR TITLE
fix: gate dependency checks on issue_dependencies_summary active count

### DIFF
--- a/agents/backlog-auditor.md
+++ b/agents/backlog-auditor.md
@@ -226,9 +226,11 @@ Stale items are items where a release closed without completing all planned work
 
 For every Project item, fetch its relationships:
 
-- Blockers: `gh api "repos/<owner>/<repo>/issues/<n>/dependencies/blocked_by"`
-- Blocking: `gh api "repos/<owner>/<repo>/issues/<n>/dependencies/blocking"`
-- Sub-issue parent: `gh issue view <n> --json parent --jq '.parent'`
+1. **Dependency pre-check**: fetch the item's dependency summary: `gh api "repos/<owner>/<repo>/issues/<n>" --jq '.issue_dependencies_summary'`
+   - If `issue_dependencies_summary.blocked_by == 0` → the item has no active blockers. Skip the `blocked_by` list fetch entirely for this item.
+   - If `issue_dependencies_summary.blocked_by > 0` → fetch the blocker list: `gh api "repos/<owner>/<repo>/issues/<n>/dependencies/blocked_by"`. When iterating this list, skip any entry where `state == "closed"` — closed blockers are satisfied by design (see policy note below). Apply per-item dependency checks only to `state == "open"` entries and to entries that return `404` (dangling).
+2. Blocking: `gh api "repos/<owner>/<repo>/issues/<n>/dependencies/blocking"`
+3. Sub-issue parent: `gh issue view <n> --json parent --jq '.parent'`
 
 If the Dependencies API returns `404` on this repo (feature unavailable on the current plan), skip this section and emit one informational line: `Issue Dependencies API unavailable — dependency audit skipped.`
 
@@ -236,7 +238,7 @@ If the Dependencies API returns `404` on this repo (feature unavailable on the c
 
 Flag each of the following as a Quality or Consistency issue:
 
-- **Dangling blocker** — referenced issue does not exist (deleted / transferred without redirect). Critical.
+- **Dangling blocker** — an open or unresolvable entry in the `blocked_by` list where fetching the blocker returns `404` (deleted / transferred without redirect). A `closed` blocker is satisfied by design and is never flagged as dangling. Critical.
 - **Cross-Project blocker** — a blocker that exists but is NOT in the linked Project. Permitted by design (e.g. infra issue tracked elsewhere) but flagged as a smell so the user can verify it's intentional. Consistency.
 - **Stale blocker** — a blocker in a CLOSED milestone while THIS item is in the active milestone. Suggests the dep was meant to be resolved but wasn't. Quality.
 - **Blocked active-milestone item with priority:P0** — surface as a Critical risk so the user knows their highest-severity work is gated. When the blocker carries `type:external-blocker`, include the stub title alongside the blocked item so the source of the constraint is immediately visible.

--- a/commands/execute-backlog-item.md
+++ b/commands/execute-backlog-item.md
@@ -108,12 +108,14 @@ Before declaring a winner, walk the rank-ordered candidate list and skip any ite
 
 For each candidate in rank order (Tier 1 first, then Tier 2):
 
-- Fetch its blockers: `gh api "repos/<owner>/<repo>/issues/<n>/dependencies/blocked_by"`
-- For each blocker:
+- **Active-blocker pre-check**: fetch `gh api "repos/<owner>/<repo>/issues/<n>" --jq '.issue_dependencies_summary.blocked_by'`.
+  - If the count is `0` → the item has no active blockers. Treat it as unblocked and skip the `blocked_by` list fetch entirely.
+  - If the count is `> 0` → fetch the blocker list: `gh api "repos/<owner>/<repo>/issues/<n>/dependencies/blocked_by"` and apply the checks below.
+- For each blocker in the list:
   - If `state == "open"`, the candidate is BLOCKED. Skip it. Record the candidate + its open blockers in a "skipped because blocked" list.
   - If `state == "closed"`, the blocker is satisfied (regardless of how it was closed — merged PR, manual close, transferred, deleted)
   - **Cross-Project / cross-repo blockers are permitted.** If the blocker lives in a different repo, query it via `gh api "repos/<blocker-owner>/<blocker-repo>/issues/<blocker-number>" --jq '.state'`. The blocker URL on the dependency response includes the full repo reference.
-- If a candidate has no blockers OR every blocker is closed, it is the winner. Stop walking.
+- If a candidate has no active blockers (pre-check count is 0) OR every fetched blocker is closed, it is the winner. Stop walking.
 
 Outcomes:
 

--- a/commands/refine-backlog-item.md
+++ b/commands/refine-backlog-item.md
@@ -57,8 +57,10 @@ Bring the target issue to a fully refined state where:
 - Existing `### INVEST Notes` content — this is where `migrate-backlog` parks open questions
 - **Current relationships** (fetched via `gh api`):
   - If the Dependencies API returns `404` on this repo (private repo without paid plan), skip blocker/blocking fields and emit one warning: `Issue Dependencies API unavailable on this repo — dependency display and updates skipped.`
-  - Blockers (`blocked_by`): list each with `#N`, title, state. Cross-Project / cross-repo blockers explicitly flagged. If a blocker carries `type:external-blocker`, display it as `External: <stub title>` (e.g. `External: Vendor API rate limit freeze`) to distinguish it from regular issue dependencies.
-    - `gh api "repos/<owner>/<repo>/issues/<n>/dependencies/blocked_by"`
+  - Blockers (`blocked_by`):
+    - First, check `gh api "repos/<owner>/<repo>/issues/<n>" --jq '.issue_dependencies_summary.blocked_by'`.
+    - If the active count is `0` → display `No active blockers` (skip the full list fetch).
+    - If the active count is `> 0` → fetch `gh api "repos/<owner>/<repo>/issues/<n>/dependencies/blocked_by"` and display only entries where `state == "open"`. Cross-Project / cross-repo blockers explicitly flagged. If a blocker carries `type:external-blocker`, display it as `External: <stub title>` (e.g. `External: Vendor API rate limit freeze`) to distinguish it from regular issue dependencies.
   - Blocking: list each with `#N`, title, state.
     - `gh api "repos/<owner>/<repo>/issues/<n>/dependencies/blocking"`
   - Sub-issue parent (if any): `#N`, title.


### PR DESCRIPTION
## Summary

- **`agents/backlog-auditor.md`** (Section 8.5): Added a dependency pre-check that reads `issue_dependencies_summary.blocked_by` before fetching the full `blocked_by` list. Skips the list fetch when count is 0; when the list is fetched, skips `state == "closed"` entries. Clarified the dangling-blocker definition: a closed blocker is satisfied by design and is never flagged as dangling.
- **`commands/execute-backlog-item.md`** (Step 2.5): Added an active-blocker pre-check per candidate that reads `issue_dependencies_summary.blocked_by` first. Skips the `blocked_by` list fetch entirely when the count is 0, and updated the winner condition to reflect the pre-check.
- **`commands/refine-backlog-item.md`** (Step 2): Added a gate on `issue_dependencies_summary.blocked_by` before displaying blockers. When the active count is 0, displays "No active blockers" without fetching the list. When > 0, fetches and displays only `state == "open"` entries.

Closes #106