### PR TITLE
fix: resolve backlog-preflight path when invoked from user project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,14 +30,14 @@ When editing any skill, these must stay consistent across files. Most consistenc
 grep -hoE "type:[a-z-]+" skills/*/SKILL.md | sort -u           # 10 type labels
 grep -hoE "priority:P[0-3]" skills/*/SKILL.md | sort -u         # 4 priority labels
 grep -hoE "effort:(XS|S|M|L|XL)\b" skills/*/SKILL.md | sort -u  # 5 effort labels
-grep -n "bin/backlog-preflight" skills/*/SKILL.md               # all consumer skills delegate preflight to the shared script
+grep -n "backlog-preflight" skills/*/SKILL.md                   # all consumer skills delegate preflight to the shared script
 grep -n "No Backlog project linked" bin/backlog-preflight       # canonical stop string lives here (single source of truth)
 grep -n ".claude/backlog-project.json" skills/*/SKILL.md        # metadata file referenced everywhere
 ```
 
 1. **Label catalog** — `type:{feature,bug,security,performance,dx,tech-debt,reliability,compliance,spike,external-blocker}`, `priority:{P0,P1,P2,P3}`, `effort:{XS,S,M,L,XL}`, plus `needs-clarification`. Any new value or rename must be applied in all skill files. `type:external-blocker` is infrastructure-only — never assigned to work items.
 
-2. **Standard preflight stop string** — the canonical stop string `No Backlog project linked to <owner>/<repo>. Run /initialize first.` is enforced in `bin/backlog-preflight`. Every consumer skill delegates its entire Section 0 to that script rather than re-implementing the checks inline. Do not re-inline the preflight logic in any skill.
+2. **Standard preflight stop string** — the canonical stop string `No Backlog project linked to <owner>/<repo>. Run /initialize first.` is enforced in `bin/backlog-preflight`. Every consumer skill delegates its entire Section 0 to that script (invoked by name as `backlog-preflight`, not by relative path) rather than re-implementing the checks inline. Do not re-inline the preflight logic in any skill.
 
 3. **Issue Forms template body shape** — section headings `### What`, `### Why`, `### In Scope`, `### Out of Scope`, `### Acceptance Criteria`, `### INVEST Notes` (in this order). `audit` parses these by exact match. `add-item`, `migrate`, `refine-item` all emit bodies that conform. The template itself is authored at runtime by `initialize` (NOT committed in this repo) and goes out via PR, never direct commit.
 
@@ -76,8 +76,8 @@ Never skip signing or the DCO sign-off (`--no-gpg-sign`, omitting `-s`).
 ## When editing skills
 
 - Match the existing style: numbered workflow sections with `(MANDATORY)` / `(STRICT)` / `(RELATIVE)` flags, opening prose `You are an AI agent acting as...`, `Rules & Constraints` section, `Output Expectations` section.
-- New consumer skills MUST add Section 0 as a single delegation to `bin/backlog-preflight` — never re-implement the preflight checks inline.
-- **`bin/` vs `scripts/`**: `bin/` holds PATH-discoverable executables callable via the Bash tool (e.g. `bin/backlog-preflight`). `scripts/` holds hook event handlers invoked by the Claude Code harness (e.g. the `SessionStart` hook). Do not mix the two: shared preflight and other AI-callable helpers belong in `bin/`; hook scripts belong in `scripts/`.
+- New consumer skills MUST add Section 0 as a single delegation to `backlog-preflight` — never re-implement the preflight checks inline.
+- **`bin/` vs `scripts/`**: `bin/` holds executables added to the Bash tool's PATH by the plugin infrastructure (e.g. `backlog-preflight`). Call them by name — not by relative path — since the Bash tool's CWD is the user's project root, not the plugin directory. `scripts/` holds hook event handlers invoked by the Claude Code harness (e.g. the `SessionStart` hook). Do not mix the two: shared preflight and other AI-callable helpers belong in `bin/`; hook scripts belong in `scripts/`.
 - After non-trivial edits, run the consistency greps above and verify no spurious bucket/Bucket leftovers (`grep -nE "[Bb]ucket" skills/*/SKILL.md` should be empty — that term was renamed to `type` in this repo's history).
 - All `gh` errors must be surfaced verbatim — never swallow.
 

--- a/skills/add-external-blocker/SKILL.md
+++ b/skills/add-external-blocker/SKILL.md
@@ -23,7 +23,7 @@ Create a lightweight stub issue (`type:external-blocker`) that represents an ext
 
 ### 0. Preflight (MANDATORY)
 
-Run `bin/backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
 
 ---
 

--- a/skills/add-item/SKILL.md
+++ b/skills/add-item/SKILL.md
@@ -17,7 +17,7 @@ Your goal is to define, refine, prioritize, and add high-quality backlog items t
 
 ### 0. Preflight (MANDATORY)
 
-Run `bin/backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
 
 ---
 

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -23,7 +23,7 @@ Validate that the backlog meets all defined quality, consistency, and integrity 
 
 ### 0. Preflight (MANDATORY)
 
-Run `bin/backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
 
 ---
 

--- a/skills/block-item/SKILL.md
+++ b/skills/block-item/SKILL.md
@@ -21,7 +21,7 @@ Register a `blocked_by` dependency between two GitHub issues: mark issue `#N` as
 
 ### 0. Preflight (MANDATORY)
 
-Run `bin/backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
 
 ---
 

--- a/skills/close-release/SKILL.md
+++ b/skills/close-release/SKILL.md
@@ -21,7 +21,7 @@ Close a GitHub Milestone cleanly: resolve every open issue interactively, satisf
 
 ### 0. Preflight (MANDATORY)
 
-Run `bin/backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
 
 ---
 

--- a/skills/execute-item/SKILL.md
+++ b/skills/execute-item/SKILL.md
@@ -21,7 +21,7 @@ Select and execute the highest-priority actionable backlog item, scoped to the a
 
 ### 0. Preflight (MANDATORY)
 
-Run `bin/backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
 
 ---
 

--- a/skills/github-backlog-management/SKILL.md
+++ b/skills/github-backlog-management/SKILL.md
@@ -53,7 +53,7 @@ Every Workable Item passes INVEST (Independent, Negotiable, Valuable, Estimable,
 
 **Metadata file**: `.claude/backlog-project.json` — written by `initialize`, read directly by all other skills.
 
-**Standard preflight**: all consumer skills run `bin/backlog-preflight` (a shared executable in `bin/`) as Step 0. On success it emits the metadata JSON; on failure it prints the canonical stop string and exits non-zero. The canonical stop string is: `No Backlog project linked to <owner>/<repo>. Run /initialize first.`
+**Standard preflight**: all consumer skills run `backlog-preflight` (a shared executable by the plugin infrastructure) as Step 0. On success it emits the metadata JSON; on failure it prints the canonical stop string and exits non-zero. The canonical stop string is: `No Backlog project linked to <owner>/<repo>. Run /initialize first.`
 
 **Priority vs rank**: `priority:*` is severity classification. Project rank (topmost Todo item) is execution order. They should stay consistent but are independent concepts — `execute-item` sorts by rank only.
 

--- a/skills/health/SKILL.md
+++ b/skills/health/SKILL.md
@@ -23,7 +23,7 @@ Produce a Markdown strategic portfolio health report covering: open-issue distri
 
 ### 0. Preflight (MANDATORY)
 
-Run `bin/backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
 
 ---
 

--- a/skills/initialize/SKILL.md
+++ b/skills/initialize/SKILL.md
@@ -30,7 +30,7 @@ Make the repository ready to host backlog items as GitHub Issues, prioritized in
 **Re-run / idempotent case** — if `.claude/backlog-project.json` already exists, delegate to the shared preflight script:
 
 ```sh
-bin/backlog-preflight
+backlog-preflight
 ```
 
 If it exits non-zero, STOP and surface the error verbatim. If it exits zero, continue to step 5.

--- a/skills/migrate/SKILL.md
+++ b/skills/migrate/SKILL.md
@@ -29,7 +29,7 @@ Transform ALL existing backlog items into GitHub Issues while:
 
 ### 0. Preflight (MANDATORY)
 
-Run `bin/backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
 
 ---
 

--- a/skills/plan-release/SKILL.md
+++ b/skills/plan-release/SKILL.md
@@ -26,7 +26,7 @@ Either:
 
 ### 0. Preflight (MANDATORY)
 
-Run `bin/backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
 
 ---
 

--- a/skills/refine-item/SKILL.md
+++ b/skills/refine-item/SKILL.md
@@ -30,7 +30,7 @@ Bring the target issue to a fully refined state where:
 
 ### 0. Preflight (MANDATORY)
 
-Run `bin/backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
 
 ---
 

--- a/skills/refine/SKILL.md
+++ b/skills/refine/SKILL.md
@@ -21,7 +21,7 @@ Walk every selected item from two candidate pools — `needs-clarification` issu
 
 ### 0. Preflight (MANDATORY)
 
-Run `bin/backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
 
 ---
 

--- a/skills/release-status/SKILL.md
+++ b/skills/release-status/SKILL.md
@@ -23,7 +23,7 @@ Produce a Markdown release health dashboard for a target milestone: issue counts
 
 ### 0. Preflight (MANDATORY)
 
-Run `bin/backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
 
 ---
 

--- a/skills/resolve-external-blocker/SKILL.md
+++ b/skills/resolve-external-blocker/SKILL.md
@@ -21,7 +21,7 @@ Close an external-blocker stub issue (created by `/add-external-blocker`) with a
 
 ### 0. Preflight (MANDATORY)
 
-Run `bin/backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
 
 ---
 

--- a/skills/setup-permissions/SKILL.md
+++ b/skills/setup-permissions/SKILL.md
@@ -21,7 +21,7 @@ These are the canonical allowlist blocks for each mode:
 
 **yolo** — no prompts during any multi-step skill:
 ```json
-["Bash(gh *)", "Bash(git *)", "Bash(bin/backlog-preflight)"]
+["Bash(gh *)", "Bash(git *)", "Bash(backlog-preflight)"]
 ```
 
 **safe** — read-only `gh` calls run silently; write commands still prompt:
@@ -37,7 +37,7 @@ These are the canonical allowlist blocks for each mode:
   "Bash(gh project item-list *)",
   "Bash(gh project field-list *)",
   "Bash(gh release list *)",
-  "Bash(bin/backlog-preflight)"
+  "Bash(backlog-preflight)"
 ]
 ```
 


### PR DESCRIPTION
## Summary

- Consumer skills were calling `bin/backlog-preflight` by relative path, which fails when the plugin runs inside a user project (the Bash tool's CWD is the user's project root, which has no `bin/` directory).
- Per the Claude Code plugin spec, executables placed in a plugin's `bin/` directory are automatically added to the Bash tool's `PATH` when the plugin is enabled. The correct invocation is `backlog-preflight` (by name, no path prefix).
- Updated all 13 consumer skills, `skills/initialize/SKILL.md`, `skills/github-backlog-management/SKILL.md`, `skills/setup-permissions/SKILL.md`, and `CLAUDE.md` to use the correct invocation.

## Acceptance Criteria

- [x] Running any plugin skill from a user project that does NOT have a local `bin/backlog-preflight` completes Step 0 without error.
- [x] No manual steps beyond a normal plugin install and `/initialize` are required for the fix to take effect.
- [x] All existing preflight behavior is fully preserved.
- [x] Skills that previously aborted at Step 0 now proceed past the preflight successfully.

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)