### PR TITLE
feat: route fixed-choice prompts to AskUserQuestion across skills

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -173,6 +173,19 @@ Done items (historical work is not migrated), and offers opt-in Dependency infer
 `/migrate`.
 _Avoid_: import (acceptable informally; "Migration" is the named activity)
 
+## Interaction Patterns
+
+**AskUserQuestion usage criterion**:
+Use `AskUserQuestion` when the set of valid responses is finite, known before the prompt is shown, and no response requires follow-up prose. Leave all other interactions as free-form conversation.
+
+Examples that qualify: item gate (Apply / Skip / Apply All Remaining / Stop Migration), milestone yes/no, label disambiguation (P0–P3, effort sizes, contextually-likely types), resume-vs-new-pick.
+
+Examples that do NOT qualify: plan approval (where "request changes" needs prose), spike findings sign-off (the user's answer IS the edits), rank-order confirmation (often needs explanation), apply-all-changes gate (where "yes but change X first" is common).
+
+Note: `AskUserQuestion` supports 2–4 options per call. For fixed catalogs larger than 4 (e.g. the 10 type values), offer the 3–4 most contextually relevant options; the tool automatically adds "Other" for free-form input.
+
+---
+
 ## Flagged ambiguities
 
 **Priority vs Rank** — these are independent and must never be conflated. Priority is a

--- a/docs/adr/0002-askuserquestion-for-fixed-choice-prompts.md
+++ b/docs/adr/0002-askuserquestion-for-fixed-choice-prompts.md
@@ -1,0 +1,15 @@
+# Use AskUserQuestion only for fixed-choice prompts where all valid responses are finite and known in advance
+
+Every interactive prompt that has a finite, pre-known set of valid responses and requires no follow-up prose uses `AskUserQuestion`. All other interactions remain free-form conversation.
+
+The criterion: **Use `AskUserQuestion` when the set of valid responses is finite, known before the prompt is shown, and no response requires follow-up prose.**
+
+Prompts migrated under this rule: item-by-item migration gate (Apply / Skip / Apply All Remaining / Stop Migration), milestone assignment yes/no, dependency inference bulk confirm (Accept all / Cherry-pick / Reject all), refine queue selection (multiSelect for ≤ 4 items), between-item continue/stop, in-progress resume-vs-new-pick, Status field customization choice, Issue template replacement choice, and label disambiguation for unclear `type:*`, `priority:*`, and `effort:*` classifications.
+
+Prompts explicitly left as free-form: plan approval in `execute-item` (users routinely answer "request changes" or "yes but move X first"), spike findings sign-off (the user's free-text response IS the edits to the document), rank-order confirmation in `add-item` and `refine-item` (users frequently add rationale or redirect), and the apply-all-changes gate in `refine-item` (partial acceptance with prose adjustments is common).
+
+## Considered Options
+
+**All interactive prompts → AskUserQuestion** — rejected because `AskUserQuestion` renders as a structured widget. Conversational prompts where "request changes" or "yes but do X first" are normal responses would force users into the "Other" free-text escape hatch on every interaction, degrading UX relative to plain prose.
+
+**All prompts remain free-form** — rejected because fixed-choice gates (Y/N/All/Stop) that rely on parsing typed replies are fragile: the executing AI must interpret free text and can misread ambiguous input. `AskUserQuestion` eliminates that parsing entirely.

--- a/skills/add-item/SKILL.md
+++ b/skills/add-item/SKILL.md
@@ -80,9 +80,9 @@ Delegate classification to the `label-classifier` agent:
 
 Handle the returned verdict:
 
-- `type:*` — if the agent returns `unclear: type`, STOP and ask the user for clarification before proceeding
-- `priority:*` — if the agent returns `unclear: priority`, present the reasoning and ask the user to decide; default to `priority:P2` only if the user explicitly accepts
-- `effort:*` — if the agent returns `unclear: effort`, present the reasoning and ask the user to resolve before proceeding
+- `type:*` — if the agent returns `unclear: type`, STOP and use AskUserQuestion, offering the 3–4 most contextually likely types as options (choose from: `feature`, `bug`, `security`, `performance`, `dx`, `tech-debt`, `reliability`, `compliance`, `spike`, `external-blocker`); "Other" is automatically provided for anything not listed
+- `priority:*` — if the agent returns `unclear: priority`, present the reasoning and use AskUserQuestion with options: `P0` / `P1` / `P2` / `P3`; default to `priority:P2` only if the user explicitly selects it
+- `effort:*` — if the agent returns `unclear: effort`, present the reasoning and use AskUserQuestion with the 4 most contextually relevant sizes as options (from `XS`, `S`, `M`, `L`, `XL`); "Other" is automatically provided for the fifth
 
 `type:external-blocker` is reserved for infrastructure stubs created by `/add-external-blocker` — DO NOT classify work items with this type; if the agent returns it or the user attempts to, STOP and redirect them to `/add-external-blocker`.
 

--- a/skills/execute-item/SKILL.md
+++ b/skills/execute-item/SKILL.md
@@ -55,11 +55,11 @@ Before picking a new item, check whether the authenticated user already has work
    | #N | ... | v0.x.x | type:... | ✅ PR #M open (waiting review) |
    | #N | ... | — | type:... | 🔧 No PR yet (work in progress) |
 
-   Then ask: "You have N in-progress item(s) — resume one, or pick a new item?"
-   - **Resume chosen:** selected item becomes winner. Skip Steps 2, 2.5, 2.6, 3, 5, and 6.
+   Then use AskUserQuestion with options built dynamically: one option per in-progress item (title + PR status, e.g. "fix/auth-bug — PR #42 open" or "feat/dashboard — no PR yet") plus a final "Pick a new item" option.
+   - **In-progress item chosen:** that item becomes winner. Skip Steps 2, 2.5, 2.6, 3, 5, and 6.
      Advise the user to check out the existing branch (`<type>/<slug>`).
      If a linked PR exists, skip Step 9 as well. Proceed to Step 4.
-   - **New item chosen:** proceed to Step 2 normally.
+   - **"Pick a new item" chosen:** proceed to Step 2 normally.
 5. **If no matching In-Progress items:** proceed to Step 2 normally.
 
 ---

--- a/skills/initialize/SKILL.md
+++ b/skills/initialize/SKILL.md
@@ -83,7 +83,7 @@ If no matching Project exists:
   - `Todo`
   - `In Progress`
   - `Done`
-- If the user has customized the Status field options, STOP and ask the user to confirm whether to add the missing options or rename existing ones — DO NOT silently overwrite
+- If the user has customized the Status field options, STOP and use AskUserQuestion with options: "Add missing options" / "Rename existing options" / "Cancel" — DO NOT silently overwrite
 
 ---
 
@@ -142,7 +142,7 @@ If `.github/ISSUE_TEMPLATE/backlog-item.yml` already exists on the default branc
 - Read its current contents
 - Compare against the canonical version below
 - If they match, SKIP step 5b
-- If they differ, STOP and ask the user whether to open a PR replacing it (do NOT silently overwrite user customizations)
+- If they differ, STOP and use AskUserQuestion with options: "Open PR to replace" / "Keep existing" — do NOT silently overwrite user customizations
 
 #### 5b. Open the template PR
 

--- a/skills/migrate/SKILL.md
+++ b/skills/migrate/SKILL.md
@@ -151,7 +151,7 @@ Done items are historical and would only clutter the Project. Their PR shipped r
 - Primary sort: `due_on` ascending (milestones without a `due_on` are sorted last)
 - Tie-break: lowest version, parsed from milestone title (e.g. `v1.2.0` < `v1.3.0`; `2026-Q2` < `2026-Q3`). For non-parseable titles, fall back to milestone `number` ascending (creation order).
 - Fallback: if NO open milestone has a `due_on`, the active milestone is the open milestone with the lowest version (same parsing rule). For non-parseable titles, fall back to milestone `number` ascending.
-- If an active milestone is found, ask the user once (before any issue is created) whether to assign all migrated items to it. Record the answer — it applies to all items uniformly.
+- If an active milestone is found, ask the user once (before any issue is created) using AskUserQuestion with options: "Yes, assign all" / "No, skip". Record the answer — it applies to all items uniformly.
 - If no active milestone exists, skip milestone assignment entirely and note it in the Migration Report.
 
 #### 8c. Create issues
@@ -172,11 +172,11 @@ For each non-Done item, in priority order (P0 → P3):
    AC:       <first line of ### Acceptance Criteria>
    ```
 
-   Prompt: `Apply this item? [Y / N / All / Stop]`
-   - `Y` — proceed with creation for this item
-   - `N` — skip this item; record as "skipped by user" in the Migration Report; continue to next item
-   - `All` — set a flag so the prompt is not shown for any remaining items; proceed with this item immediately
-   - `Stop` — halt migration immediately; report how many items were created so far vs. how many remain; do NOT create any further issues
+   Use AskUserQuestion with options:
+   - "Apply" — proceed with creation for this item
+   - "Skip" — skip this item; record as "skipped by user" in the Migration Report; continue to next item
+   - "Apply All Remaining" — set a flag so the prompt is not shown for any remaining items; proceed with this item immediately
+   - "Stop Migration" — halt migration immediately; report how many items were created so far vs. how many remain; do NOT create any further issues
 
 1. Write the constructed body to a temp file
 2. Create the issue:
@@ -219,7 +219,7 @@ This map is used in 8e to resolve dependency hints to concrete issue IDs.
      → sub-issue of #<parent-num> "<parent-title>" (evidence: "part of API rework")
    ```
 
-4. **Apply only after explicit confirmation.** The user can accept all, reject all, or cherry-pick. For each accepted candidate:
+4. **Apply only after explicit confirmation.** Use AskUserQuestion with options: "Accept all" / "Cherry-pick" / "Reject all". For "Cherry-pick", follow up with a numbered list so the user can identify which candidates to apply. For each accepted candidate:
    - `blocked_by`: delegate to `/block-item #<this-num> #<target-num>`
    - `blocking`: `gh api -X POST "repos/<o>/<r>/issues/<this-num>/dependencies/blocking" -f issue_id=<target-id>`
    - sub-issue parent: `gh api -X POST "repos/<o>/<r>/issues/<parent-num>/sub_issues" -f sub_issue_id=<this-id>`

--- a/skills/refine-item/SKILL.md
+++ b/skills/refine-item/SKILL.md
@@ -144,7 +144,10 @@ Compare the agent's verdict against the currently applied labels and propose cha
 - `effort:*` (complexity, NOT time)
 - `type:*` (if classification is now clearer)
 
-If the agent returns `unclear` for a group, surface the reasoning and ask the user to decide.
+If the agent returns `unclear` for a group, surface the reasoning and use AskUserQuestion:
+- `unclear: type` — offer the 3–4 most contextually likely types (from `feature`, `bug`, `security`, `performance`, `dx`, `tech-debt`, `reliability`, `compliance`, `spike`); "Other" is automatically provided for anything not listed
+- `unclear: priority` — offer options: `P0` / `P1` / `P2` / `P3`
+- `unclear: effort` — offer the 4 most contextually relevant sizes (from `XS`, `S`, `M`, `L`, `XL`); "Other" is automatically provided for the fifth
 
 Apply changes ONLY after explicit user confirmation:
 

--- a/skills/refine/SKILL.md
+++ b/skills/refine/SKILL.md
@@ -86,13 +86,14 @@ Omit a section header entirely if its pool is empty.
 
 ### 3. Candidate Selection
 
-After displaying the queue, ask the user which items to refine:
+After displaying the queue, select items to refine:
 
-> Which items would you like to refine? Enter:
-> - Issue numbers from the `#` column above, separated by commas (e.g. `1, 3`)
-> - A range (e.g. `1-3`)
-> - `all` to refine every item in the queue
-> - You may combine and exclude: `all -2` means all except item 2 from the list
+- **Queue of ≤ 4 items** — use AskUserQuestion with multiSelect enabled, offering one option per queue item (`#N — <title>`) plus an "All" option. Build the ordered work list from the user's selections, preserving queue order.
+- **Queue of > 4 items** — present the queue and accept free-form input:
+  - Issue numbers from the `#` column above, separated by commas (e.g. `1, 3`)
+  - A range (e.g. `1-3`)
+  - `all` to refine every item in the queue
+  - Combine and exclude: `all -2` means all except item 2 from the list
 
 Build the ordered work list from the user's answer, preserving queue order.
 
@@ -104,9 +105,8 @@ For each selected item in work-list order:
 
 1. Print: `--- Refining item N of M: #<issue-number> — <title> ---`
 2. Invoke `/refine-item <issue-number>`
-3. After the single-item skill completes, ask:
-   > Continue to the next item? [Y = yes / S = stop / Enter = yes]
-4. If the user answers S (or any equivalent like "stop", "no", "done"), break the loop and jump to step 5.
+3. After the single-item skill completes, use AskUserQuestion with options: "Continue" / "Stop"
+4. If the user selects "Stop", break the loop and jump to step 5.
 
 The loop is safe to interrupt at any point — re-running `/refine` will rebuild the queue from scratch, and already-refined items (label removed) will drop out automatically.
 


### PR DESCRIPTION
## Summary

- Replace all free-text fixed-choice gates (`[Y / N / All / Stop]`, `[Y = yes / S = stop / Enter = yes]`) with `AskUserQuestion` calls across `migrate`, `refine`, `execute-item`, `initialize`, `add-item`, and `refine-item`
- Leave conversational prompts (plan approval, spike findings sign-off, rank confirmation, apply-all-changes gate) as free-form — documented in `CONTEXT.md` and `docs/adr/0002`
- Add ADR 0002 recording the decision criterion and the options considered

Closes #104