### PR TITLE
feat(execute-item): automate --milestone flag on gh pr create

### DIFF
--- a/docs/adr/0003-pr-project-traceability-via-closes-not-project-flag.md
+++ b/docs/adr/0003-pr-project-traceability-via-closes-not-project-flag.md
@@ -1,0 +1,11 @@
+# PR–Project traceability via `Closes #N`, not `--project` flag
+
+`execute-item` does not pass `--project` to `gh pr create`. Project traceability is handled entirely by the `Closes #N` reference in the PR body, which creates a linked-PR relationship on the Issue's existing Project card.
+
+`gh pr create --project <title>` adds the PR as a separate, independent card in the Project board. In Projects v2 this means two items in the Queue for the same unit of work: the Issue card (Status = In Progress) and a new PR card (Status = Todo by default). The PR card pollutes both the board and the Queue — `/execute-item`'s candidate selection does not filter by `type:*`, so the PR card can surface as a candidate.
+
+## Considered Options
+
+**`gh pr create --project <title>`** — rejected because it adds a duplicate PR card to the Project board, polluting the Queue and making PR items eligible for candidate selection in `/execute-item`.
+
+**`gh project item-add`** — rejected for the same reason: it adds the PR as a separate Project item rather than associating it with the existing Issue card.

--- a/skills/execute-item/SKILL.md
+++ b/skills/execute-item/SKILL.md
@@ -372,7 +372,7 @@ For `type:spike` items, additionally:
 
 - Commit using Conventional Commits format. Include `Refs #<issue-number>` in the commit body.
 - Push the branch.
-- Open a Pull Request via `gh pr create`. PR body MUST include:
+- Open a Pull Request via `gh pr create`, passing `--milestone "<milestone-title>"` when the issue has one (from the Step 3 fetch; omit for un-milestoned items). PR body MUST include:
   - `Closes #<issue-number>` (so GitHub auto-links and auto-closes the issue on merge)
   - A summary of changes mapped to each Acceptance Criterion
 


### PR DESCRIPTION
## Summary

- When `execute-item` opens a PR for an issue with a milestone, it now passes `--milestone "<milestone-title>"` to `gh pr create` (milestone read from the Step 3 issue fetch)
- When the issue has no milestone (Tier 2 item), the flag is omitted entirely

## Acceptance Criteria

- [x] AC 4: When the executing issue has a milestone, `execute-item` passes `--milestone <milestone-title>` to `gh pr create`
- [x] AC 5: When the executing issue has no milestone (Tier 2), `execute-item` omits `--milestone` from the `gh pr create` call

Also includes `docs/adr/0003-pr-project-traceability-via-closes-not-project-flag.md`, documenting why `--project` is not used (decided in the same session that scoped this issue).

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)