### PR TITLE
feat(close-release): attach release-prep PR to milestone and surface URL

### DIFF
--- a/skills/close-release/SKILL.md
+++ b/skills/close-release/SKILL.md
@@ -123,7 +123,15 @@ Collect all items from 3.1 and 3.2 into a unified checklist. Classify each as on
 1. Make all required file changes.
 2. Commit using Conventional Commits format: `chore(release): prepare <milestone-title>` (no issue reference in the commit body).
 3. Push to a branch `chore/release-prep-<milestone-title>` and open a PR:
-   `gh pr create --title "chore(release): prepare <milestone-title>" --body "Release prep for <milestone-title>. Milestone: <milestone-url>."`
+
+   ```sh
+   gh pr create \
+     --title "chore(release): prepare <milestone-title>" \
+     --milestone "<milestone-title>" \
+     --body "Release prep for <milestone-title>. Milestone: <milestone-url>."
+   ```
+
+   Capture the resulting PR URL from stdout.
 4. Use **AskUserQuestion** to inform the user and wait for confirmation before proceeding:
 
    > Release prep PR opened: `<PR URL>`
@@ -240,6 +248,7 @@ Print:
   - Closed as won't fix: #N list (or "none")
   - Returned to backlog: #N list (or "none")
 - Pre-closure checklist: items performed (file PR merged, manual steps confirmed) or "no requirements found"
+- Release prep PR: <URL> → milestone <milestone-title>  (omitted when no release-prep PR was opened)
 - GitHub Release draft URL
 - Pushed git tag: `<milestone-title>` (annotated, triggers `on: push: tags:` workflows)
 - Next steps:


### PR DESCRIPTION
## Summary

- Adds `--milestone "<milestone-title>"` to the `gh pr create` command in Step 3.3 so the release-prep PR is linked to the milestone on GitHub.
- Captures the resulting PR URL from stdout.
- Surfaces the PR URL conditionally in the Step 7 Output Summary (omitted when no release-prep PR was opened).

## AC coverage

| AC | Change |
|----|--------|
| `gh pr create` includes `--milestone "<milestone-title>"` | Step 3.3 command updated |
| PR URL captured from stdout | "Capture the resulting PR URL from stdout." sentence added |
| URL appears in Step 7 Output Summary (conditional) | New bullet after pre-closure checklist line |

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)