### PR TITLE
perf: extract active milestone resolution into bin/resolve-milestone

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -108,8 +108,12 @@ mean the planning concept.
 **Active Release**:
 The Release work currently targets by default: the earliest open Milestone by `due_on`,
 tie-broken by lowest version parsed from the title (`v1.2.0` < `v1.3.0`), falling back to
-Milestone `number`. `/execute-backlog-item`, `/add-backlog-item`, and `/release-status` all
-resolve to this when no Release is named.
+Milestone `number`. `/execute-item`, `/add-item`, `/migrate`, and `/release-status` all
+resolve to this when no Release is named. When a Release name is given, it is matched by
+case-insensitive title substring, then by stripping a leading `v` from both sides.
+Resolved at runtime by `bin/resolve-milestone` (no-arg → Active Release; positional arg →
+named Release; `--exclude "<title>"` → Active Release skipping one Milestone by exact title).
+Output: `{"number": N, "title": "...", "due_on": "..."}` — `due_on` is `null` when unset.
 _Avoid_: current milestone, current release
 
 **Release artifact**:

--- a/bin/resolve-milestone
+++ b/bin/resolve-milestone
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+exclude_title=""
+positional_arg=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --exclude)
+      if [[ $# -lt 2 ]]; then
+        echo "Usage error: --exclude requires a title argument." >&2
+        exit 1
+      fi
+      exclude_title="$2"
+      shift 2
+      ;;
+    -*)
+      echo "Usage error: unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      if [[ -n "$positional_arg" ]]; then
+        echo "Usage error: multiple positional arguments not supported." >&2
+        exit 1
+      fi
+      positional_arg="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -n "$positional_arg" && -n "$exclude_title" ]]; then
+  echo "Usage error: cannot combine a milestone name argument with --exclude." >&2
+  exit 1
+fi
+
+metadata_file=".claude/backlog-project.json"
+if [[ ! -f "$metadata_file" ]]; then
+  echo "No .claude/backlog-project.json found. Run /initialize first." >&2
+  exit 1
+fi
+owner=$(jq -r '.owner' "$metadata_file")
+repo=$(jq -r '.repo' "$metadata_file")
+
+milestones=$(gh api "repos/${owner}/${repo}/milestones?state=open&per_page=100") || {
+  echo "Failed to fetch milestones from ${owner}/${repo}. Check gh authentication and repository access." >&2
+  exit 1
+}
+
+if [[ -n "$positional_arg" ]]; then
+  # Named milestone resolution — two-pass match
+  # Pass 1: case-insensitive substring of title
+  match=$(echo "$milestones" | jq --arg arg "$positional_arg" \
+    '[.[] | select((.title | ascii_downcase) | contains($arg | ascii_downcase))] | .[0]')
+
+  if [[ "$match" == "null" ]]; then
+    # Pass 2: strip leading v from both arg and each title, then compare
+    stripped_arg="${positional_arg#v}"
+    match=$(echo "$milestones" | jq --arg stripped "$stripped_arg" \
+      '[.[] | select((.title | ltrimstr("v")) == $stripped)] | .[0]')
+  fi
+
+  if [[ "$match" == "null" ]]; then
+    echo "No open milestone matching \"${positional_arg}\" found." >&2
+    exit 1
+  fi
+
+  echo "$match" | jq '{number: .number, title: .title, due_on: .due_on}'
+  exit 0
+fi
+
+# No-arg: Active Release resolution
+if [[ -n "$exclude_title" ]]; then
+  milestones=$(echo "$milestones" | jq --arg excl "$exclude_title" '[.[] | select(.title != $excl)]')
+fi
+
+count=$(echo "$milestones" | jq 'length')
+if [[ "$count" -eq 0 ]]; then
+  echo "No open milestones found." >&2
+  exit 1
+fi
+
+# Sort milestones:
+# 1. due_on ascending (null last)
+# 2. version parsed from title: strip leading v, split on ".", compare numerically per segment
+#    Non-parseable titles (e.g. "2026-Q2") fall through to number fallback
+# 3. milestone number ascending (creation order) as final tie-break
+echo "$milestones" | jq '
+  sort_by([
+    (if .due_on == null then 1 else 0 end),
+    (.due_on // ""),
+    (
+      .title
+      | ltrimstr("v")
+      | split(".")
+      | if (length > 0) and all(.[]; test("^[0-9]+$"))
+        then [0] + map(tonumber)
+        else [1]
+        end
+    ),
+    .number
+  ]) | .[0] | {number: .number, title: .title, due_on: .due_on}'

--- a/skills/add-item/SKILL.md
+++ b/skills/add-item/SKILL.md
@@ -235,19 +235,12 @@ Print the resolved relationships so the user can confirm before continuing to mi
 
 ### 9. Milestone Assignment (OPTIONAL, RECOMMENDED)
 
-The active milestone is determined as follows:
-
-- `gh api "repos/<owner>/<repo>/milestones?state=open&per_page=100"`
-- Primary sort: `due_on` ascending (milestones without a `due_on` are sorted last)
-- Tie-break: lowest version, parsed from milestone title (e.g. `v1.2.0` < `v1.3.0`; `2026-Q2` < `2026-Q3`). For non-parseable titles, fall back to milestone `number` ascending (creation order).
-- Fallback: if NO open milestone has a `due_on`, the active milestone is the open milestone with the lowest version (same parsing rule). For non-parseable titles, fall back to milestone `number` ascending (creation order).
+Run `resolve-milestone` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON — `{"number": N, "title": "...", "due_on": "..."}`. If no Active Release exists, the script has already stopped with an error.
 
 Ask the user whether to assign this item to the active milestone:
 
 - If yes: `gh issue edit <n> --milestone "<milestone-title>"`
 - If no: leave unassigned (will be picked up by `execute-item` only after items in the active milestone are exhausted)
-
-If no active milestone exists, suggest the user run `/plan-release` after.
 
 ---
 

--- a/skills/close-release/SKILL.md
+++ b/skills/close-release/SKILL.md
@@ -27,20 +27,9 @@ Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surfac
 
 ### 1. Milestone Resolution (MANDATORY)
 
-The skill accepts an optional milestone argument (title substring, number, or version string).
+The skill accepts an optional milestone argument (title substring or version string).
 
-**With argument** — resolve from open milestones via `gh api "repos/<owner>/<repo>/milestones?state=open&per_page=100"`:
-
-1. If the argument is a plain integer, match by milestone `number`.
-2. Otherwise, match by case-insensitive substring of `title`.
-3. If no substring match, try version string matching: strip a leading `v` from both the argument and each `title` before comparing (e.g. `1.2.0` matches `v1.2.0`).
-4. If no match is found after all three passes, STOP and output: `No open milestone matching "<argument>" found.`
-
-**Without argument** — use the canonical active-milestone logic:
-
-- Primary sort: `due_on` ascending; milestones with no `due_on` are sorted last.
-- Tie-break: lowest version parsed from milestone `title` (`v1.2.0` < `v1.3.0`; for non-parseable titles, fall back to milestone `number` ascending).
-- If NO open milestones exist, STOP and output: `No open milestones found.`
+Run `resolve-milestone "<argument>"` if an argument was provided, or `resolve-milestone` (no argument) for the Active Release. If it exits non-zero, STOP and surface its output verbatim.
 
 Display the resolved milestone title, number, `due_on`, and open/closed issue counts. Use **AskUserQuestion** to ask for explicit confirmation before proceeding — **closing a milestone is irreversible**.
 
@@ -57,7 +46,7 @@ If there are no open issues, skip to Step 3.
 For each open issue, use **AskUserQuestion** to present it (number, title, labels, URL) and ask the user to choose exactly one of three options:
 
 **A — Carry forward**: reassign the issue to the next open milestone.
-  - Resolve "next" using the same canonical tie-break logic as milestone resolution, but exclude the current milestone. If no other open milestone exists, STOP and output: `No next milestone exists to carry #<n> forward. Create one with /plan-release first.`
+  - Run `resolve-milestone --exclude "<current-milestone-title>"` to find the next Active Release. If it exits non-zero (no other open milestones), STOP and output: `No next milestone exists to carry #<n> forward. Create one with /plan-release first.`
   - Execute: `gh issue edit <n> --milestone "<next-milestone-title>"`
 
 **B — Close as won't fix**: close the issue and record the disposition.

--- a/skills/execute-item/SKILL.md
+++ b/skills/execute-item/SKILL.md
@@ -27,13 +27,7 @@ Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surfac
 
 ### 1. Active Milestone Detection
 
-The active milestone is determined as follows:
-
-- `gh api "repos/<owner>/<repo>/milestones?state=open&per_page=100"`
-- Primary sort: `due_on` ascending (milestones without a `due_on` are sorted last)
-- Tie-break: lowest version, parsed from milestone title (e.g. `v1.2.0` < `v1.3.0`; `2026-Q2` < `2026-Q3`). For non-parseable titles, fall back to milestone `number` ascending (creation order).
-- Fallback: if NO open milestone has a `due_on`, the active milestone is the open milestone with the lowest version (same parsing rule). For non-parseable titles, fall back to milestone `number` ascending (creation order).
-- Record the active milestone (or note that there are no open milestones at all).
+Run `resolve-milestone` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON — `{"number": N, "title": "...", "due_on": "..."}`. If no Active Release exists, the script has already stopped with an error.
 
 ---
 

--- a/skills/migrate/SKILL.md
+++ b/skills/migrate/SKILL.md
@@ -147,12 +147,9 @@ Done items are historical and would only clutter the Project. Their PR shipped r
 
 #### 8b. Resolve active milestone
 
-- `gh api "repos/<owner>/<repo>/milestones?state=open&per_page=100"`
-- Primary sort: `due_on` ascending (milestones without a `due_on` are sorted last)
-- Tie-break: lowest version, parsed from milestone title (e.g. `v1.2.0` < `v1.3.0`; `2026-Q2` < `2026-Q3`). For non-parseable titles, fall back to milestone `number` ascending (creation order).
-- Fallback: if NO open milestone has a `due_on`, the active milestone is the open milestone with the lowest version (same parsing rule). For non-parseable titles, fall back to milestone `number` ascending.
-- If an active milestone is found, ask the user once (before any issue is created) using AskUserQuestion with options: "Yes, assign all" / "No, skip". Record the answer — it applies to all items uniformly.
-- If no active milestone exists, skip milestone assignment entirely and note it in the Migration Report.
+Run `resolve-milestone` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON — `{"number": N, "title": "...", "due_on": "..."}`. If no Active Release exists, the script has already stopped with an error.
+
+Ask the user once (before any issue is created) using AskUserQuestion with options: "Yes, assign all" / "No, skip". Record the answer — it applies to all items uniformly.
 
 #### 8c. Create issues
 

--- a/skills/plan-release/SKILL.md
+++ b/skills/plan-release/SKILL.md
@@ -32,14 +32,12 @@ Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surfac
 
 ### 1. Argument Detection (MANDATORY)
 
-Check whether the skill was invoked with an argument (a milestone identifier: title, number, or version string).
+Check whether the skill was invoked with an argument (a milestone identifier: title substring or version string).
 
 - **No argument** — proceed to Step 2 (creation mode).
-- **Argument provided** — search open milestones for a match:
-  - `gh api "repos/<owner>/<repo>/milestones?state=open&per_page=100"`
-  - Match by: exact title, milestone number, or version string (e.g. `v1.2.0` matches a title of `v1.2.0`).
-  - **Match found** — skip Steps 2–10 and proceed to the Re-planning Workflow (Steps R1–R5).
-  - **No match found** — ask: "No open milestone found matching `<argument>`. Would you like to plan a new release instead?"
+- **Argument provided** — run `resolve-milestone "<argument>"` via the Bash tool:
+  - **Exit 0 (match found)** — skip Steps 2–10 and proceed to the Re-planning Workflow (Steps R1–R5).
+  - **Exit non-zero (no match)** — ask: "No open milestone found matching `<argument>`. Would you like to plan a new release instead?"
     - If yes: proceed to Step 2 (creation mode), carrying the argument as a suggested version name for Step 6.
     - If no: STOP.
 
@@ -224,7 +222,7 @@ Print:
   - >40 pts → Very Large
   - Items with no effort label counted as M=3, with a note.
 - Version bump rationale (semver only: bump type and triggering items)
-- Position in the open-milestones queue (which is the active one based on earliest `due_on`)
+- Active milestone: run `resolve-milestone` (no-arg) after creation and indicate whether the newly created milestone is now the Active Release (i.e. whether its `number` matches the script's `number` output)
 - For Mode A: forward-port clones created (list of new issue URLs), or "Forward-porting skipped"
 - Pointer to next steps:
   - "Run `/add-item` to add more items to this milestone"

--- a/skills/release-status/SKILL.md
+++ b/skills/release-status/SKILL.md
@@ -29,20 +29,9 @@ Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surfac
 
 ### 1. Milestone Resolution (MANDATORY)
 
-The skill accepts an optional milestone argument (title substring, number, or version string).
+The skill accepts an optional milestone argument (title substring or version string).
 
-**With argument** — resolve from open milestones via `gh api "repos/<owner>/<repo>/milestones?state=open&per_page=100"`:
-
-1. If the argument is a plain integer, match by milestone `number`.
-2. Otherwise, match by case-insensitive substring of `title`.
-3. If no substring match, try version string matching: strip a leading `v` from both the argument and each `title` before comparing (e.g. `1.2.0` matches `v1.2.0`).
-4. If no match is found after all three passes, STOP and output: `No open milestone matching "<argument>" found.`
-
-**Without argument** — use the canonical active-milestone logic:
-
-- Primary sort: `due_on` ascending; milestones with no `due_on` are sorted last.
-- Tie-break: lowest version parsed from milestone `title` (`v1.2.0` < `v1.3.0`; for non-parseable titles, fall back to milestone `number` ascending).
-- If NO open milestones exist, STOP and output: `No open milestones found.`
+Run `resolve-milestone "<argument>"` if an argument was provided, or `resolve-milestone` (no argument) for the Active Release. If it exits non-zero, STOP and surface its output verbatim.
 
 ---
 

--- a/skills/setup-permissions/SKILL.md
+++ b/skills/setup-permissions/SKILL.md
@@ -21,7 +21,7 @@ These are the canonical allowlist blocks for each mode:
 
 **yolo** — no prompts during any multi-step skill:
 ```json
-["Bash(gh *)", "Bash(git *)", "Bash(backlog-preflight)"]
+["Bash(gh *)", "Bash(git *)", "Bash(backlog-preflight)", "Bash(resolve-milestone*)"]
 ```
 
 **safe** — read-only `gh` calls run silently; write commands still prompt:
@@ -37,7 +37,8 @@ These are the canonical allowlist blocks for each mode:
   "Bash(gh project item-list *)",
   "Bash(gh project field-list *)",
   "Bash(gh release list *)",
-  "Bash(backlog-preflight)"
+  "Bash(backlog-preflight)",
+  "Bash(resolve-milestone*)"
 ]
 ```
 


### PR DESCRIPTION
## Summary

- Adds `bin/resolve-milestone` — a PATH-discoverable bash executable that encapsulates the active milestone resolution algorithm (earliest `due_on`, version tie-break via jq numeric segment comparison, number fallback for non-parseable titles)
- Rewires 6 skill files (`execute-item`, `add-item`, `migrate`, `release-status`, `close-release`, `plan-release`) to delegate milestone resolution to the script instead of inlining sort prose
- Removes integer-by-number milestone matching from `release-status`, `close-release`, and `plan-release`; canonical form is now two-pass only (substring → strip-`v`)
- Adds `resolve-milestone` to `setup-permissions` allowlists (yolo + safe modes)
- `CONTEXT.md` updates from grilling session (updated `Active Release` contract, corrected stale skill references)

## API

```bash
resolve-milestone                    # Active Release (no-arg)
resolve-milestone "v1.2"             # named milestone (two-pass match)
resolve-milestone --exclude "v0.6.0" # Active Release, skipping one title
```

Output on success: `{"number": N, "title": "...", "due_on": "..."}` (due_on is null, not omitted, when unset)

Closes #140