### PR TITLE
perf: extract add-item steps 6–9 into bin/create-item

### DIFF
--- a/agents/rank-recommender.md
+++ b/agents/rank-recommender.md
@@ -2,6 +2,7 @@
 name: rank-recommender
 model: sonnet
 effort: medium
+disallowedTools: Write, Edit
 allowedTools: Bash (gh project item-list *)
 description: Recommends where a candidate backlog item should sit in the Project's Todo column. Returns a concrete position, per-dimension rationale, and a flag when the recommended rank diverges from what the priority label would imply.
 ---
@@ -29,10 +30,10 @@ You receive:
 
 ```bash
 gh project item-list <project_number> --owner <owner> \
-  --format json --limit 200 --query "is:issue status:Todo"
+  --format json --limit 200 --query "is:issue status:Todo -label:type:external-blocker"
 ```
 
-Read `<project_number>` and `<owner>` from `.claude/backlog-project.json`. The response order is the current rank (top first). For each item capture its `content.number`, title, and `type:*`/`priority:*`/`effort:*` labels.
+Read `<project_number>` and `<owner>` from `.claude/backlog-project.json`. The response order is the current rank (top first). For each item capture its `content.number`, `content.body`, title, and `type:*`/`priority:*`/`effort:*` labels.
 
 ---
 

--- a/agents/rank-recommender.md
+++ b/agents/rank-recommender.md
@@ -2,15 +2,15 @@
 name: rank-recommender
 model: sonnet
 effort: medium
-disallowedTools: Write, Edit
+allowedTools: Bash (gh project item-list *)
 description: Recommends where a candidate backlog item should sit in the Project's Todo column. Returns a concrete position, per-dimension rationale, and a flag when the recommended rank diverges from what the priority label would imply.
 ---
 
 # rank-recommender
 
-You are a stateless rank analyst. Your sole job is to recommend where a candidate backlog item should be positioned within an existing Todo column, based on relative analysis across five dimensions.
+You are a rank analyst. Your sole job is to recommend where a candidate backlog item should be positioned within an existing Todo column, based on relative analysis across five dimensions.
 
-You do NOT create, edit, or delete any files or issues. You only read the input provided and return a recommendation.
+You do NOT create, edit, or delete any files or issues.
 
 ---
 
@@ -25,12 +25,14 @@ You receive:
   - `priority` — the assigned `priority:*` label (P0–P3)
   - `effort` — the assigned `effort:*` label (XS–XL)
 
-- **Current Todo column** (required):
-  - Ordered list (top-to-bottom = highest to lowest execution priority) of existing items, each with:
-    - `title` — the issue title
-    - `type` — the `type:*` label
-    - `priority` — the `priority:*` label
-    - `effort` — the `effort:*` label
+**Current Todo column:** fetch it yourself via:
+
+```bash
+gh project item-list <project_number> --owner <owner> \
+  --format json --limit 200 --query "is:issue status:Todo"
+```
+
+Read `<project_number>` and `<owner>` from `.claude/backlog-project.json`. The response order is the current rank (top first). For each item capture its `content.number`, title, and `type:*`/`priority:*`/`effort:*` labels.
 
 ---
 
@@ -68,9 +70,7 @@ Return EXACTLY this structure — no prose before or after:
 ```
 position: top
   OR
-position: above: <exact title of existing item>
-  OR
-position: below: <exact title of existing item>
+position: after_issue: <issue number of existing item>
   OR
 position: bottom
 
@@ -85,7 +85,7 @@ divergence_flag: <one-line explanation of the priority/rank conflict>
   (OMIT this line entirely if there is no divergence)
 ```
 
-Use the **exact** title of the neighboring item as written in the input — do not paraphrase.
+Use the **issue number** of the neighboring item (e.g. `after_issue: 45`), not its title.
 
 ---
 
@@ -95,7 +95,6 @@ Use the **exact** title of the neighboring item as written in the input — do n
 - If the Todo column is empty, always return `position: top`
 - If the candidate is a `priority:P0` item, it should rank above all non-P0 items unless a dependency prevents it — in that case, emit a `divergence_flag`
 - Do NOT consider milestone in ranking decisions
-- Do NOT fetch any external data — evaluate only what is provided
 - Do NOT write or edit any files
 - Each rationale line must be one sentence; do not use bullet points within rationale lines
 - If input is missing `what` for the candidate, evaluate using only title and labels

--- a/bin/create-item
+++ b/bin/create-item
@@ -212,7 +212,7 @@ if [[ "$n_blocked_by" -gt 0 && -n "$this_id" ]]; then
     }
 
     bl_out=$(gh api -X POST "repos/${owner}/${repo}/issues/${issue_num}/dependencies/blocked_by" \
-      -f issue_id="$bl_id" 2>&1) && {
+      -F issue_id="$bl_id" 2>&1) && {
       current=$(cat "$WORK_DIR/blocked_by_applied.json")
       echo "$current" | jq ". + [$bl_num]" > "$WORK_DIR/blocked_by_applied.json"
     } || echo "blocked_by[$i]: failed to link #$bl_num: $bl_out" >> "$WARNINGS_FILE"
@@ -234,7 +234,7 @@ if [[ "$n_blocking" -gt 0 && -n "$this_id" ]]; then
     }
 
     bl_out=$(gh api -X POST "repos/${owner}/${repo}/issues/${issue_num}/dependencies/blocking" \
-      -f issue_id="$bl_id" 2>&1) && {
+      -F issue_id="$bl_id" 2>&1) && {
       current=$(cat "$WORK_DIR/blocking_applied.json")
       echo "$current" | jq ". + [$bl_num]" > "$WORK_DIR/blocking_applied.json"
     } || echo "blocking[$i]: failed to link #$bl_num: $bl_out" >> "$WARNINGS_FILE"
@@ -244,7 +244,7 @@ fi
 # ─── 8. Apply parent linkage (non-fatal) ───────────────────────────────────
 if [[ "$parent_num" != "null" && -n "$this_id" ]]; then
   parent_out=$(gh api -X POST "repos/${owner}/${repo}/issues/${parent_num}/sub_issues" \
-    -f sub_issue_id="$this_id" 2>&1) && \
+    -F sub_issue_id="$this_id" 2>&1) && \
     echo "$parent_num" > "$WORK_DIR/parent_applied.json" || \
     echo "parent: failed to link #$parent_num as parent: $parent_out" >> "$WARNINGS_FILE"
 fi

--- a/bin/create-item
+++ b/bin/create-item
@@ -30,10 +30,6 @@ touch "$WARNINGS_FILE"
 
 echo "false"  > "$WORK_DIR/rank_applied"
 echo "[]"     > "$WORK_DIR/rank_adjustments_applied.json"
-echo "[]"     > "$WORK_DIR/blocked_by_applied.json"
-echo "[]"     > "$WORK_DIR/blocking_applied.json"
-echo "null"   > "$WORK_DIR/parent_applied.json"
-echo "null"   > "$WORK_DIR/milestone_applied.json"
 
 # ─── Parse args ────────────────────────────────────────────────────────────
 input_file=""
@@ -60,12 +56,11 @@ metadata_file=".claude/backlog-project.json"
   echo "No .claude/backlog-project.json found. Run /initialize first." >&2
   exit 1
 }
-owner=$(jq -r '.owner'               "$metadata_file")
-repo=$(jq -r '.repo'                 "$metadata_file")
-proj_num=$(jq -r '.project_number'   "$metadata_file")
-proj_id=$(jq -r '.project_id'        "$metadata_file")
-status_field_id=$(jq -r '.status_field_id'          "$metadata_file")
-todo_option_id=$(jq -r '.status_options.Todo'        "$metadata_file")
+owner=$(jq -r '.owner'             "$metadata_file")
+repo=$(jq -r '.repo'               "$metadata_file")
+proj_num=$(jq -r '.project_number' "$metadata_file")
+proj_id=$(jq -r '.project_id'      "$metadata_file")
+proj_title=$(jq -r '.project_title' "$metadata_file")
 
 # ─── Parse manifest ───────────────────────────────────────────────────────
 manifest=$(cat "$input_file")
@@ -79,14 +74,34 @@ blocking_json=$(echo "$manifest" | jq -c '.blocking // []')
 parent_num=$(echo "$manifest" | jq -r '.parent // null')
 milestone_title=$(echo "$manifest" | jq -r '.milestone // null')
 
+n_blocked_by=$(echo "$blocked_by_json" | jq 'length')
+n_blocking=$(echo "$blocking_json" | jq 'length')
+
 [[ -z "$title" || "$title" == "null" ]] && { echo "Manifest missing required field: title" >&2; exit 1; }
 [[ -z "$body_file" || "$body_file" == "null" ]] && { echo "Manifest missing required field: body_file" >&2; exit 1; }
 [[ ! -f "$body_file" ]] && { echo "body_file not found: $body_file" >&2; exit 1; }
 
 # ─── 1. Create the issue ───────────────────────────────────────────────────
 labels_csv=$(echo "$labels_json" | jq -r 'join(",")')
-create_args=(--title "$title" --body-file "$body_file")
+create_args=(--title "$title" --body-file "$body_file" --project "$proj_title")
 [[ -n "$labels_csv" ]] && create_args+=(--label "$labels_csv")
+
+if [[ "$n_blocked_by" -gt 0 ]]; then
+  blocked_by_refs=$(echo "$blocked_by_json" | jq -r \
+    --arg owner "$owner" --arg repo "$repo" \
+    '[.[] | if .owner == $owner and .repo == $repo then (.number | tostring) else "https://github.com/\(.owner)/\(.repo)/issues/\(.number)" end] | join(",")')
+  create_args+=(--blocked-by "$blocked_by_refs")
+fi
+
+if [[ "$n_blocking" -gt 0 ]]; then
+  blocking_refs=$(echo "$blocking_json" | jq -r \
+    --arg owner "$owner" --arg repo "$repo" \
+    '[.[] | if .owner == $owner and .repo == $repo then (.number | tostring) else "https://github.com/\(.owner)/\(.repo)/issues/\(.number)" end] | join(",")')
+  create_args+=(--blocking "$blocking_refs")
+fi
+
+[[ "$parent_num" != "null" ]] && create_args+=(--parent "$parent_num")
+[[ "$milestone_title" != "null" ]] && create_args+=(--milestone "$milestone_title")
 
 issue_url_out=$(gh issue create "${create_args[@]}" 2>&1) || {
   echo "gh issue create failed: $issue_url_out" >&2
@@ -95,30 +110,13 @@ issue_url_out=$(gh issue create "${create_args[@]}" 2>&1) || {
 issue_url=$(echo "$issue_url_out" | tail -1)
 issue_num=$(echo "$issue_url" | grep -oE '[0-9]+$')
 
-# ─── 2. Add to project ─────────────────────────────────────────────────────
-item_out=$(gh project item-add "$proj_num" --owner "$owner" --url "$issue_url" --format json 2>&1) || {
-  echo "gh project item-add failed: $item_out" >&2
-  exit 1
-}
-item_id=$(echo "$item_out" | jq -r '.id')
-
-# ─── 3. Set Status = Todo ──────────────────────────────────────────────────
-status_out=$(gh project item-edit \
-  --id "$item_id" \
-  --project-id "$proj_id" \
-  --field-id "$status_field_id" \
-  --single-select-option-id "$todo_option_id" 2>&1) || {
-  echo "gh project item-edit (status) failed: $status_out" >&2
-  exit 1
-}
-
-# ─── 4 & 5. Apply rank + rank_adjustments (non-fatal) ─────────────────────
+# ─── 2 & 3. Apply rank + rank_adjustments (non-fatal) ─────────────────────
 todo_items=""
 n_adjustments=$(echo "$rank_adjustments_json" | jq 'length')
 
 fetch_todo_items() {
   todo_items=$(gh project item-list "$proj_num" --owner "$owner" \
-    --format json --limit 200 --query "is:issue status:Todo" 2>/dev/null) || \
+    --format json --limit 200 --query "is:issue status:Todo -label:type:external-blocker" 2>/dev/null) || \
     todo_items='{"items": []}'
 }
 
@@ -132,26 +130,31 @@ resolve_item_id() {
 if [[ "$rank_json" != "null" ]]; then
   fetch_todo_items
 
-  rank_pos=$(echo "$rank_json" | jq -r '.position // null')
-  rank_after=$(echo "$rank_json" | jq -r '.after_issue // null')
+  item_id=$(resolve_item_id "$issue_num")
+  if [[ -z "${item_id:-}" || "$item_id" == "null" ]]; then
+    echo "Rank: could not find item for #$issue_num in Todo column" >> "$WARNINGS_FILE"
+  else
+    rank_pos=$(echo "$rank_json" | jq -r '.position // null')
+    rank_after=$(echo "$rank_json" | jq -r '.after_issue // null')
 
-  after_input=""
-  if [[ "$rank_pos" == "top" ]]; then
     after_input=""
-  elif [[ "$rank_after" != "null" ]]; then
-    after_id=$(resolve_item_id "$rank_after")
-    [[ -n "${after_id:-}" && "$after_id" != "null" ]] && \
-      after_input=", afterId: \"$after_id\""
-  elif [[ "$rank_pos" == "bottom" ]]; then
-    last_id=$(echo "$todo_items" | jq -r '.items // [] | last | .id' 2>/dev/null)
-    [[ -n "${last_id:-}" && "$last_id" != "null" ]] && \
-      after_input=", afterId: \"$last_id\""
-  fi
+    if [[ "$rank_pos" == "top" ]]; then
+      after_input=""
+    elif [[ "$rank_after" != "null" ]]; then
+      after_id=$(resolve_item_id "$rank_after")
+      [[ -n "${after_id:-}" && "$after_id" != "null" ]] && \
+        after_input=", afterId: \"$after_id\""
+    elif [[ "$rank_pos" == "bottom" ]]; then
+      last_id=$(echo "$todo_items" | jq -r '.items // [] | last | .id' 2>/dev/null)
+      [[ -n "${last_id:-}" && "$last_id" != "null" ]] && \
+        after_input=", afterId: \"$last_id\""
+    fi
 
-  mutation="mutation { updateProjectV2ItemPosition(input: {projectId: \"$proj_id\", itemId: \"$item_id\"$after_input}) { items { totalCount } } }"
-  rank_out=$(gh api graphql -f query="$mutation" 2>&1) && \
-    echo "true" > "$WORK_DIR/rank_applied" || \
-    echo "Rank mutation failed: $rank_out" >> "$WARNINGS_FILE"
+    mutation="mutation { updateProjectV2ItemPosition(input: {projectId: \"$proj_id\", itemId: \"$item_id\"$after_input}) { items { totalCount } } }"
+    rank_out=$(gh api graphql -f query="$mutation" 2>&1) && \
+      echo "true" > "$WORK_DIR/rank_applied" || \
+      echo "Rank mutation failed: $rank_out" >> "$WARNINGS_FILE"
+  fi
 fi
 
 if [[ "$n_adjustments" -gt 0 ]]; then
@@ -186,89 +189,19 @@ if [[ "$n_adjustments" -gt 0 ]]; then
   done
 fi
 
-# ─── Resolve this issue's database ID (needed for dep/parent APIs) ─────────
-this_id=""
-n_blocked_by=$(echo "$blocked_by_json" | jq 'length')
-n_blocking=$(echo "$blocking_json" | jq 'length')
-
-if [[ "$n_blocked_by" -gt 0 || "$n_blocking" -gt 0 || "$parent_num" != "null" ]]; then
-  this_id_out=$(gh api "repos/${owner}/${repo}/issues/${issue_num}" --jq '.id' 2>&1) && \
-    this_id="$this_id_out" || \
-    echo "Failed to resolve database ID for #$issue_num" >> "$WARNINGS_FILE"
-fi
-
-# ─── 6. Apply blocked_by (non-fatal) ───────────────────────────────────────
-if [[ "$n_blocked_by" -gt 0 && -n "$this_id" ]]; then
-  for (( i=0; i<n_blocked_by; i++ )); do
-    bl=$(echo "$blocked_by_json" | jq ".[$i]")
-    bl_owner=$(echo "$bl" | jq -r '.owner')
-    bl_repo=$(echo "$bl" | jq -r '.repo')
-    bl_num=$(echo "$bl" | jq -r '.number')
-
-    bl_id_out=$(gh api "repos/${bl_owner}/${bl_repo}/issues/${bl_num}" --jq '.id' 2>&1) && \
-      bl_id="$bl_id_out" || {
-      echo "blocked_by[$i]: failed to resolve ID for #$bl_num" >> "$WARNINGS_FILE"
-      continue
-    }
-
-    bl_out=$(gh api -X POST "repos/${owner}/${repo}/issues/${issue_num}/dependencies/blocked_by" \
-      -F issue_id="$bl_id" 2>&1) && {
-      current=$(cat "$WORK_DIR/blocked_by_applied.json")
-      echo "$current" | jq ". + [$bl_num]" > "$WORK_DIR/blocked_by_applied.json"
-    } || echo "blocked_by[$i]: failed to link #$bl_num: $bl_out" >> "$WARNINGS_FILE"
-  done
-fi
-
-# ─── 7. Apply blocking (non-fatal) ─────────────────────────────────────────
-if [[ "$n_blocking" -gt 0 && -n "$this_id" ]]; then
-  for (( i=0; i<n_blocking; i++ )); do
-    bl=$(echo "$blocking_json" | jq ".[$i]")
-    bl_owner=$(echo "$bl" | jq -r '.owner')
-    bl_repo=$(echo "$bl" | jq -r '.repo')
-    bl_num=$(echo "$bl" | jq -r '.number')
-
-    bl_id_out=$(gh api "repos/${bl_owner}/${bl_repo}/issues/${bl_num}" --jq '.id' 2>&1) && \
-      bl_id="$bl_id_out" || {
-      echo "blocking[$i]: failed to resolve ID for #$bl_num" >> "$WARNINGS_FILE"
-      continue
-    }
-
-    bl_out=$(gh api -X POST "repos/${owner}/${repo}/issues/${issue_num}/dependencies/blocking" \
-      -F issue_id="$bl_id" 2>&1) && {
-      current=$(cat "$WORK_DIR/blocking_applied.json")
-      echo "$current" | jq ". + [$bl_num]" > "$WORK_DIR/blocking_applied.json"
-    } || echo "blocking[$i]: failed to link #$bl_num: $bl_out" >> "$WARNINGS_FILE"
-  done
-fi
-
-# ─── 8. Apply parent linkage (non-fatal) ───────────────────────────────────
-if [[ "$parent_num" != "null" && -n "$this_id" ]]; then
-  parent_out=$(gh api -X POST "repos/${owner}/${repo}/issues/${parent_num}/sub_issues" \
-    -F sub_issue_id="$this_id" 2>&1) && \
-    echo "$parent_num" > "$WORK_DIR/parent_applied.json" || \
-    echo "parent: failed to link #$parent_num as parent: $parent_out" >> "$WARNINGS_FILE"
-fi
-
-# ─── 9. Apply milestone (non-fatal) ────────────────────────────────────────
-if [[ "$milestone_title" != "null" ]]; then
-  ms_out=$(gh issue edit "$issue_num" --milestone "$milestone_title" 2>&1) && {
-    echo "$milestone_title" | jq -R '.' > "$WORK_DIR/milestone_applied.json"
-  } || echo "milestone: failed to assign \"$milestone_title\": $ms_out" >> "$WARNINGS_FILE"
-fi
-
-# ─── 10. Emit JSON blob ────────────────────────────────────────────────────
+# ─── 4. Emit JSON blob ────────────────────────────────────────────────────
 warnings_out=$(jq -nR '[inputs | select(length > 0)]' < "$WARNINGS_FILE")
 
 jq -n \
-  --arg    issue_num   "$issue_num" \
-  --arg    issue_url   "$issue_url" \
-  --argjson labels     "$labels_json" \
+  --arg    issue_num      "$issue_num" \
+  --arg    issue_url      "$issue_url" \
+  --argjson labels        "$labels_json" \
   --argjson rank_applied  "$(cat "$WORK_DIR/rank_applied")" \
   --argjson ra_applied    "$(cat "$WORK_DIR/rank_adjustments_applied.json")" \
-  --argjson milestone     "$(cat "$WORK_DIR/milestone_applied.json")" \
-  --argjson bb_applied    "$(cat "$WORK_DIR/blocked_by_applied.json")" \
-  --argjson bl_applied    "$(cat "$WORK_DIR/blocking_applied.json")" \
-  --argjson parent        "$(cat "$WORK_DIR/parent_applied.json")" \
+  --arg    milestone      "$milestone_title" \
+  --argjson blocked_by    "$(echo "$blocked_by_json" | jq '[.[].number]')" \
+  --argjson blocking      "$(echo "$blocking_json" | jq '[.[].number]')" \
+  --arg    parent         "$parent_num" \
   --argjson warnings      "$warnings_out" \
   '{
     issue:                    {number: ($issue_num | tonumber), url: $issue_url},
@@ -276,9 +209,9 @@ jq -n \
     status:                   "Todo",
     rank:                     {applied: $rank_applied},
     rank_adjustments_applied: $ra_applied,
-    milestone:                $milestone,
-    blocked_by:               $bb_applied,
-    blocking:                 $bl_applied,
-    parent:                   $parent,
+    milestone:                (if $milestone == "null" then null else $milestone end),
+    blocked_by:               $blocked_by,
+    blocking:                 $blocking,
+    parent:                   (if $parent == "null" then null else ($parent | tonumber) end),
     warnings:                 $warnings
   }'

--- a/bin/create-item
+++ b/bin/create-item
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+if [[ $# -eq 0 || "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  cat << 'EOF'
+Usage: create-item --input <json-file>
+
+Creates a GitHub issue from a manifest JSON file and adds it to the backlog project.
+Emits a JSON result blob to stdout on success. Errors go to stderr.
+
+Manifest schema (title and body_file are required; all others are optional):
+  title           string
+  body_file       path to issue body file
+  labels          array of label strings
+  rank            {"position": "top"|"bottom"} | {"after_issue": N}
+  rank_adjustments array of {"issue": N, "position": "top"} | {"issue": N, "after_issue": M}
+  blocked_by      array of {"owner": "...", "repo": "...", "number": N}
+  blocking        array of {"owner": "...", "repo": "...", "number": N}
+  parent          integer (issue number)
+  milestone       string (milestone title)
+EOF
+  exit 0
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+WARNINGS_FILE="$WORK_DIR/warnings"
+touch "$WARNINGS_FILE"
+
+echo "false"  > "$WORK_DIR/rank_applied"
+echo "[]"     > "$WORK_DIR/rank_adjustments_applied.json"
+echo "[]"     > "$WORK_DIR/blocked_by_applied.json"
+echo "[]"     > "$WORK_DIR/blocking_applied.json"
+echo "null"   > "$WORK_DIR/parent_applied.json"
+echo "null"   > "$WORK_DIR/milestone_applied.json"
+
+# ─── Parse args ────────────────────────────────────────────────────────────
+input_file=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --input)
+      [[ $# -lt 2 ]] && { echo "Usage error: --input requires a file argument." >&2; exit 1; }
+      input_file="$2"
+      shift 2
+      ;;
+    *)
+      echo "Usage error: unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+[[ -z "$input_file" ]] && { echo "Usage error: --input is required." >&2; exit 1; }
+[[ ! -f "$input_file" ]] && { echo "Input file not found: $input_file" >&2; exit 1; }
+
+# ─── Metadata ─────────────────────────────────────────────────────────────
+metadata_file=".claude/backlog-project.json"
+[[ ! -f "$metadata_file" ]] && {
+  echo "No .claude/backlog-project.json found. Run /initialize first." >&2
+  exit 1
+}
+owner=$(jq -r '.owner'               "$metadata_file")
+repo=$(jq -r '.repo'                 "$metadata_file")
+proj_num=$(jq -r '.project_number'   "$metadata_file")
+proj_id=$(jq -r '.project_id'        "$metadata_file")
+status_field_id=$(jq -r '.status_field_id'          "$metadata_file")
+todo_option_id=$(jq -r '.status_options.Todo'        "$metadata_file")
+
+# ─── Parse manifest ───────────────────────────────────────────────────────
+manifest=$(cat "$input_file")
+title=$(echo "$manifest" | jq -r '.title')
+body_file=$(echo "$manifest" | jq -r '.body_file')
+labels_json=$(echo "$manifest" | jq -c '.labels // []')
+rank_json=$(echo "$manifest" | jq -c '.rank // null')
+rank_adjustments_json=$(echo "$manifest" | jq -c '.rank_adjustments // []')
+blocked_by_json=$(echo "$manifest" | jq -c '.blocked_by // []')
+blocking_json=$(echo "$manifest" | jq -c '.blocking // []')
+parent_num=$(echo "$manifest" | jq -r '.parent // null')
+milestone_title=$(echo "$manifest" | jq -r '.milestone // null')
+
+[[ -z "$title" || "$title" == "null" ]] && { echo "Manifest missing required field: title" >&2; exit 1; }
+[[ -z "$body_file" || "$body_file" == "null" ]] && { echo "Manifest missing required field: body_file" >&2; exit 1; }
+[[ ! -f "$body_file" ]] && { echo "body_file not found: $body_file" >&2; exit 1; }
+
+# ─── 1. Create the issue ───────────────────────────────────────────────────
+labels_csv=$(echo "$labels_json" | jq -r 'join(",")')
+create_args=(--title "$title" --body-file "$body_file")
+[[ -n "$labels_csv" ]] && create_args+=(--label "$labels_csv")
+
+issue_url_out=$(gh issue create "${create_args[@]}" 2>&1) || {
+  echo "gh issue create failed: $issue_url_out" >&2
+  exit 1
+}
+issue_url=$(echo "$issue_url_out" | tail -1)
+issue_num=$(echo "$issue_url" | grep -oE '[0-9]+$')
+
+# ─── 2. Add to project ─────────────────────────────────────────────────────
+item_out=$(gh project item-add "$proj_num" --owner "$owner" --url "$issue_url" --format json 2>&1) || {
+  echo "gh project item-add failed: $item_out" >&2
+  exit 1
+}
+item_id=$(echo "$item_out" | jq -r '.id')
+
+# ─── 3. Set Status = Todo ──────────────────────────────────────────────────
+status_out=$(gh project item-edit \
+  --id "$item_id" \
+  --project-id "$proj_id" \
+  --field-id "$status_field_id" \
+  --single-select-option-id "$todo_option_id" 2>&1) || {
+  echo "gh project item-edit (status) failed: $status_out" >&2
+  exit 1
+}
+
+# ─── 4 & 5. Apply rank + rank_adjustments (non-fatal) ─────────────────────
+todo_items=""
+n_adjustments=$(echo "$rank_adjustments_json" | jq 'length')
+
+fetch_todo_items() {
+  todo_items=$(gh project item-list "$proj_num" --owner "$owner" \
+    --format json --limit 200 --query "is:issue status:Todo" 2>/dev/null) || \
+    todo_items='{"items": []}'
+}
+
+resolve_item_id() {
+  local issue_n="$1"
+  echo "$todo_items" | jq -r \
+    --argjson n "$issue_n" \
+    '.items // [] | .[] | select(.content.number == $n) | .id' 2>/dev/null | head -1
+}
+
+if [[ "$rank_json" != "null" ]]; then
+  fetch_todo_items
+
+  rank_pos=$(echo "$rank_json" | jq -r '.position // null')
+  rank_after=$(echo "$rank_json" | jq -r '.after_issue // null')
+
+  after_input=""
+  if [[ "$rank_pos" == "top" ]]; then
+    after_input=""
+  elif [[ "$rank_after" != "null" ]]; then
+    after_id=$(resolve_item_id "$rank_after")
+    [[ -n "${after_id:-}" && "$after_id" != "null" ]] && \
+      after_input=", afterId: \"$after_id\""
+  elif [[ "$rank_pos" == "bottom" ]]; then
+    last_id=$(echo "$todo_items" | jq -r '.items // [] | last | .id' 2>/dev/null)
+    [[ -n "${last_id:-}" && "$last_id" != "null" ]] && \
+      after_input=", afterId: \"$last_id\""
+  fi
+
+  mutation="mutation { updateProjectV2ItemPosition(input: {projectId: \"$proj_id\", itemId: \"$item_id\"$after_input}) { items { totalCount } } }"
+  rank_out=$(gh api graphql -f query="$mutation" 2>&1) && \
+    echo "true" > "$WORK_DIR/rank_applied" || \
+    echo "Rank mutation failed: $rank_out" >> "$WARNINGS_FILE"
+fi
+
+if [[ "$n_adjustments" -gt 0 ]]; then
+  [[ -z "$todo_items" ]] && fetch_todo_items
+
+  for (( i=0; i<n_adjustments; i++ )); do
+    adj=$(echo "$rank_adjustments_json" | jq ".[$i]")
+    adj_issue=$(echo "$adj" | jq -r '.issue')
+    adj_after=$(echo "$adj" | jq -r '.after_issue // null')
+    adj_pos=$(echo "$adj" | jq -r '.position // null')
+
+    adj_item_id=$(resolve_item_id "$adj_issue")
+    if [[ -z "${adj_item_id:-}" || "$adj_item_id" == "null" ]]; then
+      echo "rank_adjustments[$i]: item #$adj_issue not found in Todo" >> "$WARNINGS_FILE"
+      continue
+    fi
+
+    after_input=""
+    if [[ "$adj_pos" == "top" ]]; then
+      after_input=""
+    elif [[ "$adj_after" != "null" ]]; then
+      after_id=$(resolve_item_id "$adj_after")
+      [[ -n "${after_id:-}" && "$after_id" != "null" ]] && \
+        after_input=", afterId: \"$after_id\""
+    fi
+
+    adj_mutation="mutation { updateProjectV2ItemPosition(input: {projectId: \"$proj_id\", itemId: \"$adj_item_id\"$after_input}) { items { totalCount } } }"
+    adj_out=$(gh api graphql -f query="$adj_mutation" 2>&1) && {
+      current=$(cat "$WORK_DIR/rank_adjustments_applied.json")
+      echo "$current" | jq ". + [$adj_issue]" > "$WORK_DIR/rank_adjustments_applied.json"
+    } || echo "rank_adjustments[$i]: mutation for #$adj_issue failed: $adj_out" >> "$WARNINGS_FILE"
+  done
+fi
+
+# ─── Resolve this issue's database ID (needed for dep/parent APIs) ─────────
+this_id=""
+n_blocked_by=$(echo "$blocked_by_json" | jq 'length')
+n_blocking=$(echo "$blocking_json" | jq 'length')
+
+if [[ "$n_blocked_by" -gt 0 || "$n_blocking" -gt 0 || "$parent_num" != "null" ]]; then
+  this_id_out=$(gh api "repos/${owner}/${repo}/issues/${issue_num}" --jq '.id' 2>&1) && \
+    this_id="$this_id_out" || \
+    echo "Failed to resolve database ID for #$issue_num" >> "$WARNINGS_FILE"
+fi
+
+# ─── 6. Apply blocked_by (non-fatal) ───────────────────────────────────────
+if [[ "$n_blocked_by" -gt 0 && -n "$this_id" ]]; then
+  for (( i=0; i<n_blocked_by; i++ )); do
+    bl=$(echo "$blocked_by_json" | jq ".[$i]")
+    bl_owner=$(echo "$bl" | jq -r '.owner')
+    bl_repo=$(echo "$bl" | jq -r '.repo')
+    bl_num=$(echo "$bl" | jq -r '.number')
+
+    bl_id_out=$(gh api "repos/${bl_owner}/${bl_repo}/issues/${bl_num}" --jq '.id' 2>&1) && \
+      bl_id="$bl_id_out" || {
+      echo "blocked_by[$i]: failed to resolve ID for #$bl_num" >> "$WARNINGS_FILE"
+      continue
+    }
+
+    bl_out=$(gh api -X POST "repos/${owner}/${repo}/issues/${issue_num}/dependencies/blocked_by" \
+      -f issue_id="$bl_id" 2>&1) && {
+      current=$(cat "$WORK_DIR/blocked_by_applied.json")
+      echo "$current" | jq ". + [$bl_num]" > "$WORK_DIR/blocked_by_applied.json"
+    } || echo "blocked_by[$i]: failed to link #$bl_num: $bl_out" >> "$WARNINGS_FILE"
+  done
+fi
+
+# ─── 7. Apply blocking (non-fatal) ─────────────────────────────────────────
+if [[ "$n_blocking" -gt 0 && -n "$this_id" ]]; then
+  for (( i=0; i<n_blocking; i++ )); do
+    bl=$(echo "$blocking_json" | jq ".[$i]")
+    bl_owner=$(echo "$bl" | jq -r '.owner')
+    bl_repo=$(echo "$bl" | jq -r '.repo')
+    bl_num=$(echo "$bl" | jq -r '.number')
+
+    bl_id_out=$(gh api "repos/${bl_owner}/${bl_repo}/issues/${bl_num}" --jq '.id' 2>&1) && \
+      bl_id="$bl_id_out" || {
+      echo "blocking[$i]: failed to resolve ID for #$bl_num" >> "$WARNINGS_FILE"
+      continue
+    }
+
+    bl_out=$(gh api -X POST "repos/${owner}/${repo}/issues/${issue_num}/dependencies/blocking" \
+      -f issue_id="$bl_id" 2>&1) && {
+      current=$(cat "$WORK_DIR/blocking_applied.json")
+      echo "$current" | jq ". + [$bl_num]" > "$WORK_DIR/blocking_applied.json"
+    } || echo "blocking[$i]: failed to link #$bl_num: $bl_out" >> "$WARNINGS_FILE"
+  done
+fi
+
+# ─── 8. Apply parent linkage (non-fatal) ───────────────────────────────────
+if [[ "$parent_num" != "null" && -n "$this_id" ]]; then
+  parent_out=$(gh api -X POST "repos/${owner}/${repo}/issues/${parent_num}/sub_issues" \
+    -f sub_issue_id="$this_id" 2>&1) && \
+    echo "$parent_num" > "$WORK_DIR/parent_applied.json" || \
+    echo "parent: failed to link #$parent_num as parent: $parent_out" >> "$WARNINGS_FILE"
+fi
+
+# ─── 9. Apply milestone (non-fatal) ────────────────────────────────────────
+if [[ "$milestone_title" != "null" ]]; then
+  ms_out=$(gh issue edit "$issue_num" --milestone "$milestone_title" 2>&1) && {
+    echo "$milestone_title" | jq -R '.' > "$WORK_DIR/milestone_applied.json"
+  } || echo "milestone: failed to assign \"$milestone_title\": $ms_out" >> "$WARNINGS_FILE"
+fi
+
+# ─── 10. Emit JSON blob ────────────────────────────────────────────────────
+warnings_out=$(jq -nR '[inputs | select(length > 0)]' < "$WARNINGS_FILE")
+
+jq -n \
+  --arg    issue_num   "$issue_num" \
+  --arg    issue_url   "$issue_url" \
+  --argjson labels     "$labels_json" \
+  --argjson rank_applied  "$(cat "$WORK_DIR/rank_applied")" \
+  --argjson ra_applied    "$(cat "$WORK_DIR/rank_adjustments_applied.json")" \
+  --argjson milestone     "$(cat "$WORK_DIR/milestone_applied.json")" \
+  --argjson bb_applied    "$(cat "$WORK_DIR/blocked_by_applied.json")" \
+  --argjson bl_applied    "$(cat "$WORK_DIR/blocking_applied.json")" \
+  --argjson parent        "$(cat "$WORK_DIR/parent_applied.json")" \
+  --argjson warnings      "$warnings_out" \
+  '{
+    issue:                    {number: ($issue_num | tonumber), url: $issue_url},
+    labels:                   $labels,
+    status:                   "Todo",
+    rank:                     {applied: $rank_applied},
+    rank_adjustments_applied: $ra_applied,
+    milestone:                $milestone,
+    blocked_by:               $bb_applied,
+    blocking:                 $bl_applied,
+    parent:                   $parent,
+    warnings:                 $warnings
+  }'

--- a/skills/add-item/SKILL.md
+++ b/skills/add-item/SKILL.md
@@ -104,132 +104,76 @@ If too vague → request clarification
 
 ---
 
-### 6. Issue Creation (MANDATORY)
+### 6. Issue Creation & Project Setup (MANDATORY)
 
-After validation passes:
+After validation passes, delegate all GitHub API calls to `bin/create-item`:
 
-- Write the constructed body to a temp file (avoids shell-escaping issues)
-- Create the issue:
-  - `gh issue create --title "<title>" --body-file <tmp> --label type:<x>,priority:<y>,effort:<z>`
-- Capture the returned issue URL and number
+1. Write the issue body to a temp file, e.g. `/tmp/add-item-body.md`
+2. Write the manifest JSON to `/tmp/add-item-manifest.json`:
+
+```json
+{
+  "title": "<issue title>",
+  "body_file": "/tmp/add-item-body.md",
+  "labels": ["type:<x>", "priority:<y>", "effort:<z>"],
+  "rank": <rank object — see step 7>,
+  "rank_adjustments": <array — see step 7>,
+  "blocked_by": [{"owner": "...", "repo": "...", "number": N}, ...],
+  "blocking":   [{"owner": "...", "repo": "...", "number": N}, ...],
+  "parent": <integer issue number or omit>,
+  "milestone": "<milestone title or omit>"
+}
+```
+
+Omit optional fields (`rank`, `rank_adjustments`, `blocked_by`, `blocking`, `parent`, `milestone`) when not applicable.
+
+3. Run: `bin/create-item --input /tmp/add-item-manifest.json`
+4. Capture the JSON blob emitted to stdout — use it for Step 10.
+
+If `bin/create-item` exits non-zero, STOP and surface its stderr output verbatim.
 
 ---
 
-### 7. Project Assignment & Execution Rank (MANDATORY, RELATIVE)
-
-Add the issue to the linked Project and set its initial Status:
-
-- `gh project item-add <project-number> --owner <owner> --url <issue-url>`
-- Set the Project `Status` field to `Todo`:
-  - `gh project item-edit --id <item-id> --project-id <project-id> --field-id <status-field-id> --single-select-option-id <todo-option-id>`
-- The exact field/option IDs can be retrieved via `gh project field-list <project-number> --owner <owner> --format json`
+### 7. Execution Rank (MANDATORY, RELATIVE)
 
 **Execution rank:** the order items are executed is determined by their position in the Project's `Todo` column — `execute-item` always picks the topmost item.
 
-This skill is responsible for placing the new item at the appropriate rank by RELATIVE analysis against existing Todo items, NOT defaulting to bottom-of-column.
+This skill is responsible for determining the appropriate rank by RELATIVE analysis against existing Todo items, NOT defaulting to bottom-of-column.
 
-The priority label classifies severity for filtering and reporting. It does NOT determine which item is executed next — execution order is set by position on the Project board. Severity and rank are tracked independently but should be **kept consistent** by this skill's relative analysis: a `priority:P0` item should generally land near the top of the Todo column, a `priority:P3` near the bottom, unless the user explicitly justifies a divergence.
+The priority label classifies severity for filtering and reporting. It does NOT determine which item is executed next — execution order is set by position on the Project board. Severity and rank should be **kept consistent**: a `priority:P0` item should generally land near the top of the Todo column, a `priority:P3` near the bottom, unless the user explicitly justifies a divergence.
 
-#### 7a. Fetch the current rank order
-
-- `gh project item-list <project-number> --owner <owner> --query "is:issue status:Todo" --format json --limit 200`
-- The response order is the current rank (top first).
-- For each Todo item, capture its title, `priority:*` label, and any milestone — these are the comparison set.
-
-#### 7b. Determine the new item's rank by delegating to `rank-recommender`
+#### 7a. Determine the new item's rank by delegating to `rank-recommender`
 
 Call the `rank-recommender` agent with:
 - **Candidate item**: the issue title, one-line `### What` summary, and the `type:*`, `priority:*`, `effort:*` labels from step 4
-- **Current Todo column**: the ordered list (top-to-bottom) from step 7a — each item's title and `type:*`, `priority:*`, `effort:*` labels
 
-The agent returns:
-- `position:` — `top` | `above: <item title>` | `below: <item title>` | `bottom`
+The agent fetches the current Todo list itself and returns:
+- `position:` — `top` | `after_issue: <N>` | `bottom`
 - `rationale:` — per-dimension Impact / Risk / Urgency / Frequency / Dependencies
 - `divergence_flag:` (if present) — the agent detected a priority/rank conflict; surface this to the user and ask them to confirm or override
 
-Present the agent's recommendation and rationale to the user before applying any rank change.
+Present the agent's recommendation and rationale to the user before proceeding. Normalize the output to the manifest `rank` field:
+- `position: top` → `{"position": "top"}`
+- `position: after_issue: 45` → `{"after_issue": 45}`
+- `position: bottom` → `{"position": "bottom"}`
 
-#### 7c. Surface re-rank suggestions for existing items
+#### 7b. Surface re-rank suggestions for existing items
 
 If the analysis reveals existing items that appear misranked relative to the new item OR relative to each other (e.g. a `priority:P3` sitting above a `priority:P1`), list each suggested move with rationale. DO NOT apply them silently.
 
-#### 7d. Apply rank changes (USER-CONFIRMED ONLY)
+#### 7c. Apply rank (USER-CONFIRMED ONLY)
 
-After the user confirms the proposed positions:
+After the user confirms the proposed positions, include the confirmed `rank` in the manifest and any `rank_adjustments` for re-ranked existing items. Pass them to `bin/create-item` in step 6.
 
-- For each rank change, run a GraphQL mutation via `gh api graphql`:
-
-  ```graphql
-  mutation {
-    updateProjectV2ItemPosition(input: {
-      projectId: "<project-node-id>",
-      itemId: "<item-node-id>",
-      afterId: "<existing-item-node-id-it-should-follow>"
-    }) {
-      items { totalCount }
-    }
-  }
-  ```
-
-  Use the `id` fields from the `item-list` response for both the moved item and its target neighbor. To move an item to the very top, omit `afterId` (or set it to `null`).
-
-- Alternatively, instruct the user to drag-drop in the Project's web UI if they prefer to apply moves manually.
-
-The skill MUST NOT apply rank changes without explicit confirmation. Always present the full proposed ordering before mutating.
+If the user prefers to apply moves manually, omit `rank` and `rank_adjustments` from the manifest and instruct the user to drag-drop in the Project's web UI.
 
 ---
 
 ### 8. Dependencies & Sub-issue Linkage
 
-Apply the relationships gathered in step 1 (Discovery). All linkages use GitHub's native APIs — they are NOT mirrored in the issue body.
+Include in the manifest any relationships gathered in step 1 (Discovery) — `blocked_by`, `blocking`, and `parent`. `bin/create-item` applies them and reports partial failures in `warnings`.
 
-If the user did not name any blockers, blocking items, or a sub-issue parent in step 1, SKIP this entire step.
-
-If the Dependencies API is unavailable on this repo (private repo without paid plan — `gh api "repos/<owner>/<repo>/issues/<number>/dependencies"` returns `404`), SKIP steps 9b–9c and emit one warning: `Issue Dependencies API unavailable on this repo — blockers/blocking not applied.` Step 9d (sub-issue parent) is unaffected if the user named one.
-
-#### 9a. Resolve numeric issue IDs
-
-The Dependencies and Sub-issues REST APIs use the issue's numeric `id` (database ID), not the human-visible `number`. For each referenced issue (this issue + every blocker / blocked / parent target):
-
-- `gh api "repos/<target-owner>/<target-repo>/issues/<number>" --jq '.id'`
-
-The current issue's `id` was returned by `gh issue create`; capture it. For cross-Project / cross-repo blockers, the target may live in a different repo — resolve `<target-owner>/<target-repo>` from the issue URL the user provided.
-
-#### 9b. Apply "blocked by" relationships
-
-For each blocker the user named in step 1, delegate to `/block-item`:
-
-```text
-/block-item #<this-number> #<blocker-number>
-```
-
-GitHub allows up to 50 blockers per direction and prevents cycles automatically. Cross-Project blockers ARE permitted — they will be flagged as a smell by `audit` but not rejected here.
-
-#### 9c. Apply "blocking" relationships
-
-For each item the user said this one blocks:
-
-- `gh api -X POST "repos/<owner>/<repo>/issues/<this-number>/dependencies/blocking" -f issue_id=<blocked-id>`
-
-This is a convenience — if A blocks B, GitHub maintains both directions. Skip this step entirely if the user only declared "blocked by".
-
-#### 9d. Apply sub-issue parent linkage
-
-If the user named a parent issue:
-
-- `gh api -X POST "repos/<owner>/<repo>/issues/<parent-number>/sub_issues" -f sub_issue_id=<this-id>`
-
-A sub-issue can only have one parent. The new issue does NOT inherit the parent's milestone, priority label, effort label, or Project rank — those stay independent.
-
-#### 9e. Verify and surface
-
-Read back the applied relationships:
-
-- `gh api "repos/<owner>/<repo>/issues/<this-number>/dependencies/blocked_by" --jq '.[].number'`
-- `gh api "repos/<owner>/<repo>/issues/<this-number>/dependencies/blocking" --jq '.[].number'`
-- `gh issue view <this-number> --json parent --jq '.parent.number'` (for sub-issue parent)
-
-Print the resolved relationships so the user can confirm before continuing to milestone assignment.
+If the user did not name any blockers, blocking items, or a sub-issue parent, omit these fields entirely.
 
 ---
 
@@ -239,24 +183,24 @@ Run `resolve-milestone` via the Bash tool. If it exits non-zero, STOP and surfac
 
 Ask the user whether to assign this item to the active milestone:
 
-- If yes: `gh issue edit <n> --milestone "<milestone-title>"`
-- If no: leave unassigned (will be picked up by `execute-item` only after items in the active milestone are exhausted)
+- If yes: include `"milestone": "<milestone-title>"` in the manifest passed to `bin/create-item`
+- If no: omit the `milestone` field (will be picked up by `execute-item` only after items in the active milestone are exhausted)
 
 ---
 
 ### 10. Output
 
-Print:
+Using the JSON blob returned by `bin/create-item`, print:
 
-- Issue URL and number
-- Applied labels (type / priority / effort)
-- Project Status (Todo)
-- Milestone assignment (or "unassigned")
-- Final rank in the Project `Todo` column (e.g. "position 3 of 12, above #45 and below #38")
-- Any rank changes applied to existing items as part of relative re-prioritization
-- Blockers (`#N` list, with cross-Project / cross-repo blockers explicitly flagged) — or "none"
-- Blocking (`#N` list) — or "none"
-- Sub-issue parent (`#N`) — or "none"
+- Issue URL and number (`.issue.url`, `.issue.number`)
+- Applied labels (`.labels`)
+- Project Status (`.status`)
+- Milestone assignment (`.milestone` or "unassigned")
+- Rank applied (`.rank.applied`) and any re-ranked items (`.rank_adjustments_applied`)
+- Blockers (`.blocked_by` list, with cross-Project / cross-repo blockers explicitly flagged) — or "none"
+- Blocking (`.blocking` list) — or "none"
+- Sub-issue parent (`.parent`) — or "none"
+- Any warnings (`.warnings` — surface each one verbatim)
 
 ---
 

--- a/skills/add-item/SKILL.md
+++ b/skills/add-item/SKILL.md
@@ -28,7 +28,7 @@ Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surfac
   - Desired outcome
   - User/business impact
   - Constraints, risks, and edge cases
-- Ask about relationships to existing items (used in step 8):
+- Ask about relationships to existing items:
   - **Blocked by**: Is this item blocked by any open issue that must be done first? (provide issue numbers; cross-Project blockers are allowed — e.g. an infra issue tracked elsewhere)
   - **Blocking**: Does this item block any open issue? (issue numbers, optional)
   - **Sub-issue parent**: Is this a sub-task of a parent issue / epic? (issue number, optional — sub-issues stay independent: they do NOT inherit the parent's milestone, priority, or rank)
@@ -86,7 +86,7 @@ Handle the returned verdict:
 
 `type:external-blocker` is reserved for infrastructure stubs created by `/add-external-blocker` — DO NOT classify work items with this type; if the agent returns it or the user attempts to, STOP and redirect them to `/add-external-blocker`.
 
-These labels will be passed as `--label` flags when creating the issue in step 6.
+These labels will be passed as `labels` in the manifest in step 9.
 
 ---
 
@@ -104,33 +104,11 @@ If too vague → request clarification
 
 ---
 
-### 6. Issue Creation & Project Setup (MANDATORY)
+### 6. Dependencies & Sub-issue Linkage
 
-After validation passes, delegate all GitHub API calls to `bin/create-item`:
+Include in the manifest any relationships gathered in step 1 (Discovery) — `blocked_by`, `blocking`, and `parent`.
 
-1. Write the issue body to a temp file, e.g. `/tmp/add-item-body.md`
-2. Write the manifest JSON to `/tmp/add-item-manifest.json`:
-
-```json
-{
-  "title": "<issue title>",
-  "body_file": "/tmp/add-item-body.md",
-  "labels": ["type:<x>", "priority:<y>", "effort:<z>"],
-  "rank": <rank object — see step 7>,
-  "rank_adjustments": <array — see step 7>,
-  "blocked_by": [{"owner": "...", "repo": "...", "number": N}, ...],
-  "blocking":   [{"owner": "...", "repo": "...", "number": N}, ...],
-  "parent": <integer issue number or omit>,
-  "milestone": "<milestone title or omit>"
-}
-```
-
-Omit optional fields (`rank`, `rank_adjustments`, `blocked_by`, `blocking`, `parent`, `milestone`) when not applicable.
-
-3. Run: `bin/create-item --input /tmp/add-item-manifest.json`
-4. Capture the JSON blob emitted to stdout — use it for Step 10.
-
-If `bin/create-item` exits non-zero, STOP and surface its stderr output verbatim.
+If the user did not name any blockers, blocking items, or a sub-issue parent, omit these fields entirely.
 
 ---
 
@@ -163,34 +141,42 @@ If the analysis reveals existing items that appear misranked relative to the new
 
 #### 7c. Apply rank (USER-CONFIRMED ONLY)
 
-After the user confirms the proposed positions, include the confirmed `rank` in the manifest and any `rank_adjustments` for re-ranked existing items. Pass them to `bin/create-item` in step 6.
+After the user confirms the proposed positions, include the confirmed `rank` in the manifest and any `rank_adjustments` for re-ranked existing items. 
 
 If the user prefers to apply moves manually, omit `rank` and `rank_adjustments` from the manifest and instruct the user to drag-drop in the Project's web UI.
 
 ---
 
-### 8. Dependencies & Sub-issue Linkage
-
-Include in the manifest any relationships gathered in step 1 (Discovery) — `blocked_by`, `blocking`, and `parent`. `bin/create-item` applies them and reports partial failures in `warnings`.
-
-If the user did not name any blockers, blocking items, or a sub-issue parent, omit these fields entirely.
-
----
-
-### 9. Milestone Assignment (OPTIONAL, RECOMMENDED)
+### 8. Milestone Assignment (OPTIONAL, RECOMMENDED)
 
 Run `resolve-milestone` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON — `{"number": N, "title": "...", "due_on": "..."}`. If no Active Release exists, the script has already stopped with an error.
 
 Ask the user whether to assign this item to the active milestone:
 
-- If yes: include `"milestone": "<milestone-title>"` in the manifest passed to `bin/create-item`
+- If yes: include `"milestone": "<milestone-title>"` in the manifest passed to `create-item`
 - If no: omit the `milestone` field (will be picked up by `execute-item` only after items in the active milestone are exhausted)
+
+---
+
+### 9. Issue Creation & Project Setup (MANDATORY)
+
+After validation passes, invoke the `create-item` Bash tool to create the issue:
+
+1. Write the issue body to a temp file, e.g. `/tmp/add-item-body.md`
+2. Write the manifest JSON file, e.g. `/tmp/add-item-manifest.json`:
+
+See [issue-manifest.md](./issue-manifest.md) for the full manifest schema.
+
+3. Run: `create-item --input /tmp/add-item-manifest.json`
+4. Capture the JSON blob emitted to stdout — use it for Step 10.
+
+If `create-item` exits non-zero, STOP and surface its stderr output verbatim.
 
 ---
 
 ### 10. Output
 
-Using the JSON blob returned by `bin/create-item`, print:
+Using the JSON blob returned by `create-item`, print:
 
 - Issue URL and number (`.issue.url`, `.issue.number`)
 - Applied labels (`.labels`)
@@ -242,4 +228,3 @@ You MUST:
 - Issue URL printed for verification
 - All labels and Project state explicitly listed
 - Do NOT proceed with incomplete or ambiguous information
-- All `gh` errors surfaced verbatim

--- a/skills/add-item/issue-manifest.md
+++ b/skills/add-item/issue-manifest.md
@@ -1,0 +1,24 @@
+# Issue Manifest Schema
+
+The manifest is a JSON file passed to `create-item --input <file>`.
+
+`title` and `body_file` are required; all other fields are optional and should be omitted when not applicable.
+
+```json
+{
+  "title": "<issue title>",
+  "body_file": "/tmp/add-item-body.md",
+  "labels": ["type:<x>", "priority:<y>", "effort:<z>"],
+  "rank": {"position": "top"} | {"position": "bottom"} | {"after_issue": N},
+  "rank_adjustments": [{"issue": N, "position": "top"} | {"issue": N, "after_issue": M}],
+  "blocked_by": [{"owner": "...", "repo": "...", "number": N}],
+  "blocking":   [{"owner": "...", "repo": "...", "number": N}],
+  "parent": <integer issue number>,
+  "milestone": "<milestone title>"
+}
+```
+
+## Field Notes
+
+- `rank` / `rank_adjustments` — use `after_issue: N` with the issue number of the item to position after
+- `blocked_by` / `blocking` — cross-repo references are allowed; include `owner` and `repo` for cross-repo items; same-repo items need only `number`

--- a/skills/initialize/SKILL.md
+++ b/skills/initialize/SKILL.md
@@ -286,6 +286,7 @@ Write the file:
   "repo": "<repo>",
   "project_number": <int>,
   "project_id": "<project-node-id>",
+  "project_title": "<project-title>",
   "project_url": "<html-url>",
   "status_field_id": "<status-field-node-id>",
   "status_options": {

--- a/tests/create-item.bats
+++ b/tests/create-item.bats
@@ -1,0 +1,347 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(dirname "$(dirname "$BATS_TEST_FILENAME")")"
+  CREATE_ITEM="$REPO_ROOT/bin/create-item"
+
+  TEST_DIR="$(mktemp -d)"
+  MOCK_BIN="$(mktemp -d)"
+  export GH_MOCK_DIR="$(mktemp -d)"
+  export PATH="$MOCK_BIN:$PATH"
+
+  cd "$TEST_DIR"
+
+  mkdir -p .claude
+  cat > .claude/backlog-project.json << 'JSON'
+{
+  "owner": "testowner",
+  "repo": "testrepo",
+  "project_number": 1,
+  "project_id": "PVT_test",
+  "status_field_id": "PVTF_test",
+  "status_options": {
+    "Todo": "opt_todo",
+    "In Progress": "opt_inprogress",
+    "Done": "opt_done"
+  }
+}
+JSON
+
+  echo "Issue body content." > "$GH_MOCK_DIR/body.txt"
+
+  # gh mock — reads control flags from $GH_MOCK_DIR at runtime
+  cat > "$MOCK_BIN/gh" << 'SCRIPT'
+#!/usr/bin/env bash
+subcmd="${1:-}"
+shift || true
+
+if [[ "$subcmd" == "issue" ]]; then
+  subcmd2="${1:-}"; shift || true
+  if [[ "$subcmd2" == "create" ]]; then
+    [[ -f "$GH_MOCK_DIR/issue_create_fail" ]] && { echo "gh issue create: simulated failure" >&2; exit 1; }
+    echo "https://github.com/testowner/testrepo/issues/42"
+    exit 0
+  elif [[ "$subcmd2" == "edit" ]]; then
+    [[ -f "$GH_MOCK_DIR/milestone_fail" ]] && { echo "gh issue edit: simulated failure" >&2; exit 1; }
+    exit 0
+  fi
+
+elif [[ "$subcmd" == "project" ]]; then
+  subcmd2="${1:-}"; shift || true
+  if [[ "$subcmd2" == "item-add" ]]; then
+    [[ -f "$GH_MOCK_DIR/item_add_fail" ]] && { echo "gh project item-add: simulated failure" >&2; exit 1; }
+    echo '{"id": "PVTI_42", "type": "ISSUE", "content": {"number": 42, "url": "https://github.com/testowner/testrepo/issues/42"}}'
+    exit 0
+  elif [[ "$subcmd2" == "item-edit" ]]; then
+    [[ -f "$GH_MOCK_DIR/item_edit_fail" ]] && { echo "gh project item-edit: simulated failure" >&2; exit 1; }
+    echo '{"id": "PVTI_42"}'
+    exit 0
+  elif [[ "$subcmd2" == "item-list" ]]; then
+    cat "$GH_MOCK_DIR/items_todo.json" 2>/dev/null || echo '{"items": []}'
+    exit 0
+  fi
+
+elif [[ "$subcmd" == "api" ]]; then
+  method="GET"
+  path=""
+  jq_filter=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -X|--method) method="$2"; shift 2;;
+      -f|--field) shift 2;;
+      --jq) jq_filter="$2"; shift 2;;
+      -*) shift;;
+      *) [[ -z "$path" ]] && path="$1"; shift;;
+    esac
+  done
+
+  if [[ "$path" == "graphql" ]]; then
+    [[ -f "$GH_MOCK_DIR/graphql_fail" ]] && { echo "GraphQL: simulated failure" >&2; exit 1; }
+    echo '{"data": {"updateProjectV2ItemPosition": {"items": {"totalCount": 5}}}}'
+    exit 0
+  fi
+
+  if [[ "$method" == "POST" ]]; then
+    if [[ "$path" =~ /dependencies/blocked_by ]]; then
+      if [[ -f "$GH_MOCK_DIR/deps_404" ]]; then
+        echo "HTTP 404: Not Found" >&2; exit 1
+      fi
+      echo '{"id": 1}'; exit 0
+    fi
+    if [[ "$path" =~ /dependencies/blocking ]]; then
+      if [[ -f "$GH_MOCK_DIR/deps_404" ]]; then
+        echo "HTTP 404: Not Found" >&2; exit 1
+      fi
+      echo '{"id": 1}'; exit 0
+    fi
+    if [[ "$path" =~ /sub_issues ]]; then
+      [[ -f "$GH_MOCK_DIR/parent_fail" ]] && { echo "sub_issues: simulated failure" >&2; exit 1; }
+      echo '{"id": 1}'; exit 0
+    fi
+  fi
+
+  # GET issue by number — used for ID resolution
+  if [[ "$path" =~ ^repos/[^/]+/[^/]+/issues/[0-9]+$ ]]; then
+    num=$(echo "$path" | grep -oE '[0-9]+$')
+    result="{\"id\": 100${num}, \"number\": ${num}, \"state\": \"open\"}"
+    if [[ -n "$jq_filter" ]]; then
+      echo "$result" | jq -r "$jq_filter"
+    else
+      echo "$result"
+    fi
+    exit 0
+  fi
+
+  echo "Unhandled api: method=$method path=$path" >&2; exit 1
+fi
+
+echo "Unhandled gh: $subcmd $*" >&2
+exit 1
+SCRIPT
+  chmod +x "$MOCK_BIN/gh"
+
+  echo '{"items": []}' > "$GH_MOCK_DIR/items_todo.json"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR" "$MOCK_BIN" "$GH_MOCK_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+write_manifest() {
+  local file="$1"
+  shift
+  echo "$@" > "$file"
+}
+
+default_manifest() {
+  local file="$1"
+  cat > "$file" << JSON
+{
+  "title": "Test issue title",
+  "body_file": "$GH_MOCK_DIR/body.txt",
+  "labels": ["type:feature", "priority:P2", "effort:S"]
+}
+JSON
+}
+
+# ---------------------------------------------------------------------------
+# AC1 — --help (or no args) prints usage and exits 0
+# ---------------------------------------------------------------------------
+
+@test "AC1a: no args prints usage and exits 0" {
+  run "$CREATE_ITEM"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "AC1b: --help prints usage and exits 0" {
+  run "$CREATE_ITEM" --help
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"Usage"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC2 — Success path: valid manifest emits correct JSON blob
+# ---------------------------------------------------------------------------
+
+@test "AC2: success path emits full JSON blob with all required fields" {
+  local manifest="$GH_MOCK_DIR/manifest.json"
+  default_manifest "$manifest"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 0 ]]
+
+  issue_num=$(echo "$output" | jq -r '.issue.number')
+  [[ "$issue_num" == "42" ]]
+
+  issue_url=$(echo "$output" | jq -r '.issue.url')
+  [[ "$issue_url" == "https://github.com/testowner/testrepo/issues/42" ]]
+
+  labels=$(echo "$output" | jq -c '.labels')
+  [[ "$labels" == '["type:feature","priority:P2","effort:S"]' ]]
+
+  status=$(echo "$output" | jq -r '.status')
+  [[ "$status" == "Todo" ]]
+
+  rank_applied=$(echo "$output" | jq -r '.rank.applied')
+  [[ "$rank_applied" == "false" ]]
+
+  milestone=$(echo "$output" | jq -r '.milestone')
+  [[ "$milestone" == "null" ]]
+
+  warnings=$(echo "$output" | jq -c '.warnings')
+  [[ "$warnings" == "[]" ]]
+
+  # All required keys present (use has() to handle null values)
+  echo "$output" | jq -e 'has("rank_adjustments_applied")' > /dev/null
+  echo "$output" | jq -e 'has("blocked_by")' > /dev/null
+  echo "$output" | jq -e 'has("blocking")' > /dev/null
+  echo "$output" | jq -e 'has("parent")' > /dev/null
+}
+
+@test "AC2b: success path with rank top emits rank.applied=true" {
+  local manifest="$GH_MOCK_DIR/manifest.json"
+  cat > "$manifest" << JSON
+{
+  "title": "Ranked issue",
+  "body_file": "$GH_MOCK_DIR/body.txt",
+  "labels": ["type:performance", "priority:P1", "effort:M"],
+  "rank": {"position": "top"}
+}
+JSON
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 0 ]]
+
+  rank_applied=$(echo "$output" | jq -r '.rank.applied')
+  [[ "$rank_applied" == "true" ]]
+
+  warnings=$(echo "$output" | jq -c '.warnings')
+  [[ "$warnings" == "[]" ]]
+}
+
+@test "AC2c: success path with milestone sets milestone in output" {
+  local manifest="$GH_MOCK_DIR/manifest.json"
+  cat > "$manifest" << JSON
+{
+  "title": "Milestoned issue",
+  "body_file": "$GH_MOCK_DIR/body.txt",
+  "labels": ["type:feature", "priority:P2", "effort:S"],
+  "milestone": "v0.6.0"
+}
+JSON
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 0 ]]
+
+  milestone=$(echo "$output" | jq -r '.milestone')
+  [[ "$milestone" == "v0.6.0" ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC3 — Fatal: gh issue create fails → exit non-zero, error on stderr
+# ---------------------------------------------------------------------------
+
+@test "AC3: gh issue create failure exits non-zero with error on stderr, no stdout blob" {
+  local manifest="$GH_MOCK_DIR/manifest.json"
+  default_manifest "$manifest"
+  touch "$GH_MOCK_DIR/issue_create_fail"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -ne 0 ]]
+  # stderr should contain error (bats captures it in $output when combined)
+  # Using run's combined output check
+  [[ "$output" == *"simulated failure"* ]] || [[ "$output" == *"error"* ]] || [[ "$output" == *"fail"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC4 — Fatal: gh project item-add fails → exit non-zero
+# ---------------------------------------------------------------------------
+
+@test "AC4: gh project item-add failure exits non-zero" {
+  local manifest="$GH_MOCK_DIR/manifest.json"
+  default_manifest "$manifest"
+  touch "$GH_MOCK_DIR/item_add_fail"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -ne 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC5 — Non-fatal: rank GraphQL mutation fails → warning in blob, exit 0
+# ---------------------------------------------------------------------------
+
+@test "AC5: GraphQL rank mutation failure adds warning but exits 0" {
+  local manifest="$GH_MOCK_DIR/manifest.json"
+  cat > "$manifest" << JSON
+{
+  "title": "Ranked issue",
+  "body_file": "$GH_MOCK_DIR/body.txt",
+  "labels": ["type:feature", "priority:P1", "effort:M"],
+  "rank": {"position": "top"}
+}
+JSON
+  touch "$GH_MOCK_DIR/graphql_fail"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 0 ]]
+
+  rank_applied=$(echo "$output" | jq -r '.rank.applied')
+  [[ "$rank_applied" == "false" ]]
+
+  warnings_len=$(echo "$output" | jq '.warnings | length')
+  [[ "$warnings_len" -gt 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC6 — Non-fatal: gh issue edit --milestone fails → warning in blob, exit 0
+# ---------------------------------------------------------------------------
+
+@test "AC6: milestone assignment failure adds warning but exits 0" {
+  local manifest="$GH_MOCK_DIR/manifest.json"
+  cat > "$manifest" << JSON
+{
+  "title": "Milestoned issue",
+  "body_file": "$GH_MOCK_DIR/body.txt",
+  "labels": ["type:feature", "priority:P2", "effort:S"],
+  "milestone": "v0.6.0"
+}
+JSON
+  touch "$GH_MOCK_DIR/milestone_fail"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 0 ]]
+
+  milestone=$(echo "$output" | jq -r '.milestone')
+  [[ "$milestone" == "null" ]]
+
+  warnings_len=$(echo "$output" | jq '.warnings | length')
+  [[ "$warnings_len" -gt 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC7 — Non-fatal: Dependencies API 404 → warning in blob, exit 0
+# ---------------------------------------------------------------------------
+
+@test "AC7: Dependencies API 404 adds warning but exits 0" {
+  local manifest="$GH_MOCK_DIR/manifest.json"
+  cat > "$manifest" << JSON
+{
+  "title": "Blocked issue",
+  "body_file": "$GH_MOCK_DIR/body.txt",
+  "labels": ["type:feature", "priority:P2", "effort:S"],
+  "blocked_by": [{"owner": "testowner", "repo": "testrepo", "number": 10}]
+}
+JSON
+  touch "$GH_MOCK_DIR/deps_404"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 0 ]]
+
+  warnings_len=$(echo "$output" | jq '.warnings | length')
+  [[ "$warnings_len" -gt 0 ]]
+}

--- a/tests/create-item.bats
+++ b/tests/create-item.bats
@@ -18,6 +18,7 @@ setup() {
   "repo": "testrepo",
   "project_number": 1,
   "project_id": "PVT_test",
+  "project_title": "testowner/testrepo Backlog",
   "status_field_id": "PVTF_test",
   "status_options": {
     "Todo": "opt_todo",
@@ -29,6 +30,23 @@ JSON
 
   echo "Issue body content." > "$GH_MOCK_DIR/body.txt"
 
+  # Prepopulate Todo list with the issue the mock always creates (#42)
+  cat > "$GH_MOCK_DIR/items_todo.json" << 'JSON'
+{
+  "items": [
+    {
+      "id": "PVTI_42",
+      "type": "ISSUE",
+      "content": {
+        "number": 42,
+        "title": "Test issue title",
+        "url": "https://github.com/testowner/testrepo/issues/42"
+      }
+    }
+  ]
+}
+JSON
+
   # gh mock — reads control flags from $GH_MOCK_DIR at runtime
   cat > "$MOCK_BIN/gh" << 'SCRIPT'
 #!/usr/bin/env bash
@@ -39,24 +57,21 @@ if [[ "$subcmd" == "issue" ]]; then
   subcmd2="${1:-}"; shift || true
   if [[ "$subcmd2" == "create" ]]; then
     [[ -f "$GH_MOCK_DIR/issue_create_fail" ]] && { echo "gh issue create: simulated failure" >&2; exit 1; }
+    # Flag-specific failures
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --milestone) shift; [[ -f "$GH_MOCK_DIR/milestone_fail" ]] && { echo "gh issue create: milestone not found" >&2; exit 1; };;
+        --blocked-by) shift; [[ -f "$GH_MOCK_DIR/deps_404" ]] && { echo "gh issue create: blocked-by 404" >&2; exit 1; };;
+        *) shift;;
+      esac
+    done
     echo "https://github.com/testowner/testrepo/issues/42"
-    exit 0
-  elif [[ "$subcmd2" == "edit" ]]; then
-    [[ -f "$GH_MOCK_DIR/milestone_fail" ]] && { echo "gh issue edit: simulated failure" >&2; exit 1; }
     exit 0
   fi
 
 elif [[ "$subcmd" == "project" ]]; then
   subcmd2="${1:-}"; shift || true
-  if [[ "$subcmd2" == "item-add" ]]; then
-    [[ -f "$GH_MOCK_DIR/item_add_fail" ]] && { echo "gh project item-add: simulated failure" >&2; exit 1; }
-    echo '{"id": "PVTI_42", "type": "ISSUE", "content": {"number": 42, "url": "https://github.com/testowner/testrepo/issues/42"}}'
-    exit 0
-  elif [[ "$subcmd2" == "item-edit" ]]; then
-    [[ -f "$GH_MOCK_DIR/item_edit_fail" ]] && { echo "gh project item-edit: simulated failure" >&2; exit 1; }
-    echo '{"id": "PVTI_42"}'
-    exit 0
-  elif [[ "$subcmd2" == "item-list" ]]; then
+  if [[ "$subcmd2" == "item-list" ]]; then
     cat "$GH_MOCK_DIR/items_todo.json" 2>/dev/null || echo '{"items": []}'
     exit 0
   fi
@@ -64,12 +79,11 @@ elif [[ "$subcmd" == "project" ]]; then
 elif [[ "$subcmd" == "api" ]]; then
   method="GET"
   path=""
-  jq_filter=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -X|--method) method="$2"; shift 2;;
-      -f|--field) shift 2;;
-      --jq) jq_filter="$2"; shift 2;;
+      -f|--field|-F) shift 2;;
+      --jq) shift 2;;
       -*) shift;;
       *) [[ -z "$path" ]] && path="$1"; shift;;
     esac
@@ -81,37 +95,6 @@ elif [[ "$subcmd" == "api" ]]; then
     exit 0
   fi
 
-  if [[ "$method" == "POST" ]]; then
-    if [[ "$path" =~ /dependencies/blocked_by ]]; then
-      if [[ -f "$GH_MOCK_DIR/deps_404" ]]; then
-        echo "HTTP 404: Not Found" >&2; exit 1
-      fi
-      echo '{"id": 1}'; exit 0
-    fi
-    if [[ "$path" =~ /dependencies/blocking ]]; then
-      if [[ -f "$GH_MOCK_DIR/deps_404" ]]; then
-        echo "HTTP 404: Not Found" >&2; exit 1
-      fi
-      echo '{"id": 1}'; exit 0
-    fi
-    if [[ "$path" =~ /sub_issues ]]; then
-      [[ -f "$GH_MOCK_DIR/parent_fail" ]] && { echo "sub_issues: simulated failure" >&2; exit 1; }
-      echo '{"id": 1}'; exit 0
-    fi
-  fi
-
-  # GET issue by number — used for ID resolution
-  if [[ "$path" =~ ^repos/[^/]+/[^/]+/issues/[0-9]+$ ]]; then
-    num=$(echo "$path" | grep -oE '[0-9]+$')
-    result="{\"id\": 100${num}, \"number\": ${num}, \"state\": \"open\"}"
-    if [[ -n "$jq_filter" ]]; then
-      echo "$result" | jq -r "$jq_filter"
-    else
-      echo "$result"
-    fi
-    exit 0
-  fi
-
   echo "Unhandled api: method=$method path=$path" >&2; exit 1
 fi
 
@@ -119,8 +102,6 @@ echo "Unhandled gh: $subcmd $*" >&2
 exit 1
 SCRIPT
   chmod +x "$MOCK_BIN/gh"
-
-  echo '{"items": []}' > "$GH_MOCK_DIR/items_todo.json"
 }
 
 teardown() {
@@ -253,19 +234,24 @@ JSON
 
   run "$CREATE_ITEM" --input "$manifest"
   [[ "$status" -ne 0 ]]
-  # stderr should contain error (bats captures it in $output when combined)
-  # Using run's combined output check
   [[ "$output" == *"simulated failure"* ]] || [[ "$output" == *"error"* ]] || [[ "$output" == *"fail"* ]]
 }
 
 # ---------------------------------------------------------------------------
-# AC4 — Fatal: gh project item-add fails → exit non-zero
+# AC4 — Fatal: milestone failure is fatal (bundled into gh issue create)
 # ---------------------------------------------------------------------------
 
-@test "AC4: gh project item-add failure exits non-zero" {
+@test "AC4: milestone assignment failure is fatal" {
   local manifest="$GH_MOCK_DIR/manifest.json"
-  default_manifest "$manifest"
-  touch "$GH_MOCK_DIR/item_add_fail"
+  cat > "$manifest" << JSON
+{
+  "title": "Milestoned issue",
+  "body_file": "$GH_MOCK_DIR/body.txt",
+  "labels": ["type:feature", "priority:P2", "effort:S"],
+  "milestone": "v0.6.0"
+}
+JSON
+  touch "$GH_MOCK_DIR/milestone_fail"
 
   run "$CREATE_ITEM" --input "$manifest"
   [[ "$status" -ne 0 ]]
@@ -298,36 +284,10 @@ JSON
 }
 
 # ---------------------------------------------------------------------------
-# AC6 — Non-fatal: gh issue edit --milestone fails → warning in blob, exit 0
+# AC6 — Fatal: blocked_by failure is fatal (bundled into gh issue create)
 # ---------------------------------------------------------------------------
 
-@test "AC6: milestone assignment failure adds warning but exits 0" {
-  local manifest="$GH_MOCK_DIR/manifest.json"
-  cat > "$manifest" << JSON
-{
-  "title": "Milestoned issue",
-  "body_file": "$GH_MOCK_DIR/body.txt",
-  "labels": ["type:feature", "priority:P2", "effort:S"],
-  "milestone": "v0.6.0"
-}
-JSON
-  touch "$GH_MOCK_DIR/milestone_fail"
-
-  run "$CREATE_ITEM" --input "$manifest"
-  [[ "$status" -eq 0 ]]
-
-  milestone=$(echo "$output" | jq -r '.milestone')
-  [[ "$milestone" == "null" ]]
-
-  warnings_len=$(echo "$output" | jq '.warnings | length')
-  [[ "$warnings_len" -gt 0 ]]
-}
-
-# ---------------------------------------------------------------------------
-# AC7 — Non-fatal: Dependencies API 404 → warning in blob, exit 0
-# ---------------------------------------------------------------------------
-
-@test "AC7: Dependencies API 404 adds warning but exits 0" {
+@test "AC6: blocked_by failure is fatal" {
   local manifest="$GH_MOCK_DIR/manifest.json"
   cat > "$manifest" << JSON
 {
@@ -340,8 +300,5 @@ JSON
   touch "$GH_MOCK_DIR/deps_404"
 
   run "$CREATE_ITEM" --input "$manifest"
-  [[ "$status" -eq 0 ]]
-
-  warnings_len=$(echo "$output" | jq '.warnings | length')
-  [[ "$warnings_len" -gt 0 ]]
+  [[ "$status" -ne 0 ]]
 }


### PR DESCRIPTION
## Summary

- Adds `bin/create-item --input <json-file>` bash script that encapsulates all mechanical GitHub API calls from `add-item` steps 6–9 (issue create, project add, status set, rank mutations, dependency wiring, milestone assignment); emits a structured JSON blob to stdout on success
- Updates `rank-recommender` agent to self-fetch the current Todo list via `gh project item-list` and update its output schema to use issue numbers (`after_issue: N`) instead of item titles
- Rewires `add-item` steps 6–9 to write a JSON manifest and delegate to `bin/create-item --input`, using the output blob for Step 10

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)