### PR TITLE
refactor: align spec wording with CONTEXT.md canonical terms

### DIFF
--- a/agents/backlog-auditor.md
+++ b/agents/backlog-auditor.md
@@ -64,7 +64,7 @@ If structure is unclear or `gh` fails:
 
 ### 2. Structural Validation (MANDATORY)
 
-For EACH issue in the Project, first determine whether it is a `type:external-blocker` stub. Apply the appropriate check path — stubs and work items have different structural rules.
+For EACH issue in the Project, first determine whether it is a `type:external-blocker` stub. Apply the appropriate check path — stubs and Workable Items have different structural rules.
 
 #### 2a. Stub check path (issues with `type:external-blocker`)
 
@@ -76,7 +76,7 @@ For EACH issue in the Project, first determine whether it is a `type:external-bl
   - The content is boilerplate or non-descriptive — single words, generic phrases such as "TBD", "N/A", "Unknown", "External dependency", "External constraint", or any content that does not explain the specific nature of the constraint
 - **Project Status field**: every stub MUST have a Status set (`Todo` / `In Progress` / `Done`). Flag stubs with no Status.
 
-#### 2b. Work item check path (all other issues)
+#### 2b. Workable Item check path (all other issues)
 
 ##### Labels (exactly-one rule)
 
@@ -240,8 +240,8 @@ Flag each of the following as a Quality or Consistency issue:
 
 - **Dangling blocker** — an open or unresolvable entry in the `blocked_by` list where fetching the blocker returns `404` (deleted / transferred without redirect). A `closed` blocker is satisfied by design and is never flagged as dangling. Critical.
 - **Cross-Project blocker** — a blocker that exists but is NOT in the linked Project. Permitted by design (e.g. infra issue tracked elsewhere) but flagged as a smell so the user can verify it's intentional. Consistency.
-- **Stale blocker** — a blocker in a CLOSED milestone while THIS item is in the active milestone. Suggests the dep was meant to be resolved but wasn't. Quality.
-- **Blocked active-milestone item with priority:P0** — surface as a Critical risk so the user knows their highest-severity work is gated. When the blocker carries `type:external-blocker`, include the stub title alongside the blocked item so the source of the constraint is immediately visible.
+- **Stale blocker** — a blocker in a CLOSED milestone while THIS item is in the Active Release. Suggests the dep was meant to be resolved but wasn't. Quality.
+- **Blocked Active Release item with priority:P0** — surface as a Critical risk so the user knows their highest-severity work is gated. When the blocker carries `type:external-blocker`, include the stub title alongside the blocked item so the source of the constraint is immediately visible.
 - **Items at top of Todo column that are blocked** — they look ready to pick but `execute-item` will skip them. Consistency.
 - **Apparent cycles** — defense-in-depth: walk the `blocked_by` graph and detect back-edges. GitHub prevents direct cycles (A blocked-by B and B blocked-by A) but indirect ones via transferred issues, deleted nodes, or stale state may slip through. Critical.
 
@@ -301,14 +301,14 @@ Produce a **Validation Report** with:
 
 ### A. Critical Issues (Must Fix)
 
-- Missing required labels (`type:*` / `priority:*` / `effort:*`) on work items
-- Missing required body sections on work items
+- Missing required labels (`type:*` / `priority:*` / `effort:*`) on Workable Items
+- Missing required body sections on Workable Items
 - Missing Project Status
-- Items in active milestone missing `priority:*`
+- Items in the Active Release missing `priority:*`
 - Duplicate labels within a group
 - Dangling blockers (referenced issue does not exist)
 - Apparent dependency cycles
-- Blocked `priority:P0` items in the active milestone (include stub title when the blocker is a `type:external-blocker` stub)
+- Blocked `priority:P0` items in the Active Release (include stub title when the blocker is a `type:external-blocker` stub)
 
 ### B. Quality Issues
 
@@ -317,7 +317,7 @@ Produce a **Validation Report** with:
 - Scope problems
 - Effort issues
 - Vague or untestable criteria
-- Stale blockers (blocker in closed milestone while item is in active milestone)
+- Stale blockers (blocker in closed milestone while item is in the Active Release)
 - `type:external-blocker` stub with missing, empty, or boilerplate Reason field
 - `type:external-blocker` stub that is open but blocking no issues (orphaned)
 

--- a/agents/label-classifier.md
+++ b/agents/label-classifier.md
@@ -28,7 +28,7 @@ You receive one or more of the following:
 
 ### Type Labels
 
-Assign exactly ONE of the following. `type:external-blocker` is reserved for infrastructure stubs — NEVER assign it to a work item.
+Assign exactly ONE of the following. `type:external-blocker` is reserved for Stubs — NEVER assign it to a Workable Item.
 
 | Label | When to apply |
 | ----- | ------------- |
@@ -108,7 +108,7 @@ effort:S — confined to a single package
 ## Rules & Constraints
 
 - Return ONLY the structured output — no explanation headers, no summaries, no preamble
-- NEVER assign `type:external-blocker` to a work item — if the item is an infrastructure stub, return `unclear: type — item appears to be an external blocker stub; use /add-external-blocker instead`
+- NEVER assign `type:external-blocker` to a Workable Item — if the item is a Stub, return `unclear: type — item appears to be a Stub; use /add-external-blocker instead`
 - Do NOT suggest fixes to the issue body
 - Do NOT fetch any external data — evaluate only what is provided
 - Do NOT write or edit any files

--- a/agents/rank-recommender.md
+++ b/agents/rank-recommender.md
@@ -4,12 +4,12 @@ model: sonnet
 effort: medium
 disallowedTools: Write, Edit
 allowedTools: Bash (gh project item-list *)
-description: Recommends where a candidate backlog item should sit in the Project's Todo column. Returns a concrete position, per-dimension rationale, and a flag when the recommended rank diverges from what the priority label would imply.
+description: Recommends where a candidate backlog item should sit in the Project's Todo column. Returns a recommended Rank, per-dimension rationale, and a flag when the recommended rank diverges from what the priority label would imply.
 ---
 
 # rank-recommender
 
-You are a rank analyst. Your sole job is to recommend where a candidate backlog item should be positioned within an existing Todo column, based on relative analysis across five dimensions.
+You are a rank analyst. Your sole job is to recommend where a candidate backlog item should be ranked within the Queue, based on relative analysis across five dimensions.
 
 You do NOT create, edit, or delete any files or issues.
 
@@ -60,7 +60,7 @@ The `priority:*` label encodes severity classification. Execution rank should be
 - A `priority:P2` candidate should generally sit above all P3 items.
 - A `priority:P3` candidate should generally sit below all higher-priority items.
 
-Emit a `divergence_flag` when the recommended position conflicts with this expected ordering — i.e., a higher-priority candidate is placed below a lower-priority existing item, or a lower-priority candidate is placed above a higher-priority existing item.
+Emit a `divergence_flag` when the recommended Rank conflicts with this expected ordering — i.e., a higher-priority candidate is placed below a lower-priority existing item, or a lower-priority candidate is placed above a higher-priority existing item.
 
 ---
 

--- a/skills/add-item/SKILL.md
+++ b/skills/add-item/SKILL.md
@@ -84,7 +84,7 @@ Handle the returned verdict:
 - `priority:*` — if the agent returns `unclear: priority`, present the reasoning and use AskUserQuestion with options: `P0` / `P1` / `P2` / `P3`; default to `priority:P2` only if the user explicitly selects it
 - `effort:*` — if the agent returns `unclear: effort`, present the reasoning and use AskUserQuestion with the 4 most contextually relevant sizes as options (from `XS`, `S`, `M`, `L`, `XL`); "Other" is automatically provided for the fifth
 
-`type:external-blocker` is reserved for infrastructure stubs created by `/add-external-blocker` — DO NOT classify work items with this type; if the agent returns it or the user attempts to, STOP and redirect them to `/add-external-blocker`.
+`type:external-blocker` is reserved for Stubs created by `/add-external-blocker` — DO NOT classify Workable Items with this type; if the agent returns it or the user attempts to, STOP and redirect them to `/add-external-blocker`.
 
 These labels will be passed as `labels` in the manifest in step 9.
 
@@ -114,11 +114,11 @@ If the user did not name any blockers, blocking items, or a sub-issue parent, om
 
 ### 7. Execution Rank (MANDATORY, RELATIVE)
 
-**Execution rank:** the order items are executed is determined by their position in the Project's `Todo` column — `execute-item` always picks the topmost item.
+**Execution rank:** the order items are executed is determined by their Rank in the Queue — `execute-item` always picks the topmost item.
 
 This skill is responsible for determining the appropriate rank by RELATIVE analysis against existing Todo items, NOT defaulting to bottom-of-column.
 
-The priority label classifies severity for filtering and reporting. It does NOT determine which item is executed next — execution order is set by position on the Project board. Severity and rank should be **kept consistent**: a `priority:P0` item should generally land near the top of the Todo column, a `priority:P3` near the bottom, unless the user explicitly justifies a divergence.
+The priority label classifies severity for filtering and reporting. It does NOT determine which item is executed next — execution order is set by Rank. Severity and rank should be **kept consistent**: a `priority:P0` item should generally land near the top of the Todo column, a `priority:P3` near the bottom, unless the user explicitly justifies a divergence.
 
 #### 7a. Determine the new item's rank by delegating to `rank-recommender`
 
@@ -141,7 +141,7 @@ If the analysis reveals existing items that appear misranked relative to the new
 
 #### 7c. Apply rank (USER-CONFIRMED ONLY)
 
-After the user confirms the proposed positions, include the confirmed `rank` in the manifest and any `rank_adjustments` for re-ranked existing items. 
+After the user confirms the proposed Rank placements, include the confirmed `rank` in the manifest and any `rank_adjustments` for re-ranked existing items. 
 
 If the user prefers to apply moves manually, omit `rank` and `rank_adjustments` from the manifest and instruct the user to drag-drop in the Project's web UI.
 
@@ -151,10 +151,10 @@ If the user prefers to apply moves manually, omit `rank` and `rank_adjustments` 
 
 Run `resolve-milestone` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON — `{"number": N, "title": "...", "due_on": "..."}`. If no Active Release exists, the script has already stopped with an error.
 
-Ask the user whether to assign this item to the active milestone:
+Ask the user whether to assign this item to the Active Release:
 
 - If yes: include `"milestone": "<milestone-title>"` in the manifest passed to `create-item`
-- If no: omit the `milestone` field (will be picked up by `execute-item` only after items in the active milestone are exhausted)
+- If no: omit the `milestone` field (will be picked up by `execute-item` only after items in the Active Release are exhausted)
 
 ---
 

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -5,7 +5,7 @@ description: Audit backlog quality, INVEST compliance, and label consistency wit
 
 # audit
 
-You are an AI agent acting as a Senior Project Manager responsible for validating the quality, consistency, and integrity of the project backlog.
+You are an AI agent acting as a Senior Project Manager responsible for auditing the quality, consistency, and integrity of the project backlog.
 
 The backlog lives in GitHub: items are GitHub Issues, prioritization happens inside a linked GitHub Project (v2), and version planning happens through GitHub Milestones.
 
@@ -15,7 +15,7 @@ Your role is to run a read-only audit by delegating to the `backlog-auditor` age
 
 ## Objective
 
-Validate that the backlog meets all defined quality, consistency, and integrity standards before it is used for execution.
+Audit the backlog to confirm it meets all defined quality, consistency, and integrity standards before it is used for execution.
 
 ---
 

--- a/skills/block-item/SKILL.md
+++ b/skills/block-item/SKILL.md
@@ -13,7 +13,7 @@ The backlog lives in GitHub: items are GitHub Issues, prioritization happens ins
 
 ## Objective
 
-Register a `blocked_by` dependency between two GitHub issues: mark issue `#N` as blocked by issue `#M`. Works for any two GitHub issues — not limited to items in the linked Project or the active milestone.
+Register a `blocked_by` dependency between two GitHub issues: mark issue `#N` as blocked by issue `#M`. Works for any two GitHub issues — not limited to items in the linked Project or the active Milestone.
 
 ---
 

--- a/skills/execute-item/SKILL.md
+++ b/skills/execute-item/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: execute-item
-description: Pick and execute the highest-priority unblocked backlog item in the active milestone.
+description: Pick and execute the topmost unblocked Workable Item from the Queue.
 ---
 
 # execute-item
@@ -13,7 +13,7 @@ The backlog lives in GitHub: items are GitHub Issues, prioritization happens ins
 
 ## Objective
 
-Select and execute the highest-priority actionable backlog item, scoped to the active milestone first, then to un-milestoned items as a fallback.
+Select and execute the topmost actionable Workable Item, scoped to the Active Release first, then to un-milestoned items as a fallback.
 
 ---
 
@@ -339,7 +339,7 @@ Print:
 - Branch name
 - Assignee (the authenticated user, assigned in step 6)
 - Final Project Status (typically `In Progress` until PR merges)
-- Whether the issue was assigned to the active milestone
+- Whether the issue was assigned to the Active Release
 - Items skipped above this one because they were blocked (with `#N` and the open blockers that gated them; `type:external-blocker` blockers shown as `External: <stub title>`) — surfaces why the picked item wasn't necessarily the topmost
 - Parent items skipped because open sub-issues were found in the Project's Todo column (log: `Skipping parent #N — open sub-issues found. Picking #M.`)
 - Whether this item was **resumed** (was already In Progress) or **newly picked** (was Todo)

--- a/skills/health/SKILL.md
+++ b/skills/health/SKILL.md
@@ -34,7 +34,7 @@ Run these two queries:
 1. **All open issues**:
    `gh issue list --state open --json number,title,labels,assignees,createdAt,updatedAt,url --limit 200`
 
-   After fetching, **pre-filter**: discard any issue whose labels include `type:external-blocker` — these are infrastructure stubs, never work items, and are excluded from all counts and metrics.
+   After fetching, **pre-filter**: discard any issue whose labels include `type:external-blocker` — these are Stubs, never Workable Items, and are excluded from all counts and metrics.
 
 2. **Project membership and Status**:
    `gh project item-list <project-number> --owner <owner> --format json --limit 200 --query "is:issue"`
@@ -189,7 +189,7 @@ Emit `✅ All open items have complete label metadata.` when empty.
 ## Rules & Constraints
 
 - This skill is **strictly read-only** — never mutate any issue, Project field, milestone, or label.
-- Discard `type:external-blocker` stubs before all computations — they are not work items.
+- Discard `type:external-blocker` Stubs before all computations — they are not Workable Items.
 - Closed issues are excluded from all sections.
 - Surface all `gh` errors verbatim — never swallow.
 - Percentages rounded to the nearest integer.

--- a/skills/initialize/SKILL.md
+++ b/skills/initialize/SKILL.md
@@ -102,7 +102,7 @@ Create the standard label catalog. Use `gh label create --force` so existing lab
 - `type:reliability` — `"Uptime, error recovery, observability, or graceful-degradation improvement"`
 - `type:compliance` — `"Regulatory, legal, or contractual obligation"`
 - `type:spike` — `"Time-boxed investigation to reduce uncertainty; deliverable is knowledge"`
-- `type:external-blocker` — `"External constraint blocking a backlog item (infrastructure stub)"`
+- `type:external-blocker` — `"External constraint blocking a backlog item (Stub)"`
 
 #### Priority labels (one of these must be on every backlog item)
 
@@ -159,7 +159,7 @@ If the file is missing or the user approved replacement:
 - Push the branch: `git push -u origin chore/backlog-item-issue-template`
 - Open a PR via `gh pr create --title "chore: add backlog-item and external-blocker issue forms templates" --body "<body>"` where the body explains:
   - `backlog-item.yml` is the canonical body shape for backlog items — all skills depend on its section headings
-  - `external-blocker.yml` is the template for infrastructure stub issues created by `/add-external-blocker`
+  - `external-blocker.yml` is the template for External Blocker Stub issues created by `/add-external-blocker`
   - `audit` parses `backlog-item.yml` sections — changing them will break parsing
 - Print the PR URL
 

--- a/skills/migrate/SKILL.md
+++ b/skills/migrate/SKILL.md
@@ -7,7 +7,7 @@ description: Migrate items from a BACKLOG.md into GitHub Issues with label norma
 
 You are an AI agent acting as a Senior Project Manager responsible for migrating, normalizing, and validating backlog items into GitHub.
 
-Your goal is to convert an existing backlog (typically a `TODO.md` or `BACKLOG.md`-style markdown file the user provides) into a fully GitHub-native form: GitHub Issues with the canonical body shape, the standard `type:*`/`priority:*`/`effort:*` labels, added to the linked GitHub Project, and (optionally) assigned to the active milestone.
+Your goal is to convert an existing backlog (typically a `TODO.md` or `BACKLOG.md`-style markdown file the user provides) into a fully GitHub-native form: GitHub Issues with the canonical body shape, the standard `type:*`/`priority:*`/`effort:*` labels, added to the linked GitHub Project, and (optionally) assigned to the Active Release.
 
 The local source backlog is **input only**. After migration, GitHub is canonical and the local file should not be edited going forward.
 
@@ -145,7 +145,7 @@ Before any GitHub mutation, partition the validated items:
 
 Done items are historical and would only clutter the Project. Their PR shipped references stay in the original BACKLOG.md as a record.
 
-#### 8b. Resolve active milestone
+#### 8b. Resolve Active Release
 
 Run `resolve-milestone` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON — `{"number": N, "title": "...", "due_on": "..."}`. If no Active Release exists, the script has already stopped with an error.
 

--- a/skills/plan-release/SKILL.md
+++ b/skills/plan-release/SKILL.md
@@ -90,7 +90,7 @@ Ask the user which release mode to use:
 - Validate each resolved issue exists and is open:
   - `gh issue view <n> --json number,title,state,labels,milestone`
   - If an issue is closed or not found, surface the error and ask the user to correct the list.
-  - If any validated issue carries `type:external-blocker`, warn the user: "Issue #N is an external-blocker stub, not a work item. Stubs should not appear in release scope." Exclude the item unless the user explicitly overrides with a justification.
+  - If any validated issue carries `type:external-blocker`, warn the user: "Issue #N is an external-blocker stub, not a Workable Item. Stubs should not appear in release scope." Exclude the item unless the user explicitly overrides with a justification.
 - Display the confirmed issue list (number, title, type label, priority label, effort label) and ask for review.
 - Scan the scope for items that carry `type:feature` or any explicit breaking-change signal in `### What` / `### INVEST Notes` (read body via `gh issue view <n> --json body`). For each such item, WARN the user:
   > ⚠️ Issue #N "`<title>`" introduces new functionality / a breaking change, which is atypical for a maintenance release.
@@ -169,7 +169,7 @@ Wait for explicit user confirmation of the version name before proceeding.
 Collect from the user (with sensible defaults):
 
 - **Title** — confirmed in step 6
-- **Due date** (`due_on`) — Used by `execute-item` to determine the active milestone (earliest `due_on` wins). Format: `YYYY-MM-DDTHH:MM:SSZ`.
+- **Due date** (`due_on`) — Used by `execute-item` to determine the Active Release (earliest `due_on` wins). Format: `YYYY-MM-DDTHH:MM:SSZ`.
 - **Description** — if the user does not provide one, generate a suggested description from the confirmed scope:
   - Summarize the release theme (e.g. "Bug-fix and security hardening release", "Feature release: …", "Maintenance patch for v1.5.x")
   - List the top goals derived from the scoped items' `### Why` sections
@@ -338,7 +338,7 @@ Triggered when the user chooses "Remove items" or "Both" in Step R1.
 
 Fetch all open issues currently assigned to the milestone with Status = `Todo` (In Progress / Done items are read-only and not included).
 
-Display the current milestone Todo items in plain text before calling `AskUserQuestion`:
+Display the Milestone's Todo items in plain text before calling `AskUserQuestion`:
 
 ```text
 # | Title | Type | Priority | Effort

--- a/skills/refine-item/SKILL.md
+++ b/skills/refine-item/SKILL.md
@@ -240,7 +240,7 @@ Only after the pre-removal validation gate passes:
   - Issue URL
   - Summary of body changes
   - Label changes applied
-  - Rank change applied (e.g., "moved from position 8 to position 3")
+  - Rank change applied (e.g., "moved from Rank 8 to Rank 3")
   - Dependency changes applied (blockers added / removed, sub-issue parent change)
 
 ---

--- a/skills/refine/SKILL.md
+++ b/skills/refine/SKILL.md
@@ -125,7 +125,7 @@ After the loop ends (queue exhausted, user stopped, or all items processed), out
 
 #### Refined items
 
-For each: issue URL, label changes applied (`priority:*` / `effort:*` / `type:*`), rank change (e.g. "moved from position 8 to position 3"), milestone changes (if any).
+For each: issue URL, label changes applied (`priority:*` / `effort:*` / `type:*`), rank change (e.g. "moved from Rank 8 to Rank 3"), milestone changes (if any).
 
 #### Partially refined items
 

--- a/skills/release-status/SKILL.md
+++ b/skills/release-status/SKILL.md
@@ -42,7 +42,7 @@ With the resolved milestone in hand, run these queries:
 1. **Issues assigned to the milestone**:
    `gh issue list --state all --milestone "<milestone-title>" --json number,title,labels,state,url --limit 500`
 
-   After fetching, **partition the results**: set aside any issue whose labels include `type:external-blocker` — these are infrastructure stubs and are **excluded from all milestone counts and metrics**. They are retained only to enrich the blocked-items table with stub titles as blocker context (step 3).
+   After fetching, **partition the results**: set aside any issue whose labels include `type:external-blocker` — these are Stubs and are **excluded from all Milestone counts and metrics**. They are retained only to enrich the blocked-items table with stub titles as blocker context (step 3).
 
 2. **Project membership and Status**:
    `gh project item-list <project-number> --owner <owner> --query "is:issue milestone:<milestone-title>" --format json --limit 200`


### PR DESCRIPTION
## Summary

Wording-only sweep of `agents/*.md` and all `skills/*/SKILL.md` replacing pre-glossary and inconsistent terminology with the canonical terms defined in `CONTEXT.md`. No behavioral or logic changes — prose alignment only.

**14 files touched, 37 lines changed (pure substitution).**

## Changes by rule

- **Rule 1 — "work item" → "Workable Item"**: `backlog-auditor.md`, `label-classifier.md`, `health/SKILL.md`, `add-item/SKILL.md`, `plan-release/SKILL.md`
- **Rule 2 — "active milestone" → "Active Release" / "active Milestone"**: `backlog-auditor.md`, `execute-item/SKILL.md`, `add-item/SKILL.md`, `migrate/SKILL.md`, `plan-release/SKILL.md`, `block-item/SKILL.md`
- **Rule 3 — validate/validation as Audit activity → "audit"**: `audit/SKILL.md` (description + Objective; internal step headings left untouched)
- **Rule 4 — "infrastructure stub(s)" → "Stub(s)" / "External Blocker Stub"**: `label-classifier.md`, `health/SKILL.md`, `release-status/SKILL.md`, `initialize/SKILL.md`, `add-item/SKILL.md`
- **Rule 5 — "position" in narrative prose → "Rank"**: `rank-recommender.md` (description + body), `add-item/SKILL.md`, `refine/SKILL.md`, `refine-item/SKILL.md`
- **Rule 6 — execute-item description field**: fixed Priority/Rank conflation ("highest-priority") and "active milestone" concept in one substitution

## Acceptance Criteria verified

- `grep -rn "work item" agents/ skills/` → **0 hits** ✅
- `grep -rn "active milestone\|current milestone\|current release" agents/ skills/` → **0 hits** ✅
- `grep -rn "infrastructure stub" agents/ skills/` → **0 hits** ✅
- `validate/validation` as Audit activity name → **0 hits** ✅ (`validation report` document name in `backlog-auditor.md` left intact — names the output structure, not the activity)
- `\bposition\b` narrative prose → **1 exempt hit** (`migrate/SKILL.md:248` directly precedes `updateProjectV2ItemPosition` API call — API-level language, not the Rank concept)
- `highest-priority` → **0 hits** ✅
- `Queue` capitalisation → **consistent** ✅
- CLAUDE.md invariants (10 type labels, 4 priority labels, 5 effort labels, `backlog-preflight` stop string, `type:external-blocker` label value) → **unchanged** ✅

Closes #121