### PR TITLE
chore(release): prepare v0.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "github-backlog-management",
       "description": "GitHub-native backlog automation. Manage Issues + Projects v2 with AI-enforced INVEST quality, dependency tracking, and one-command execution.",
       "source": "./",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "category": "productivity",
       "keywords": ["github", "backlog", "issues", "projects-v2", "milestones", "labels", "invest", "agile", "prioritization"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "github-backlog-management",
   "description": "GitHub-native backlog automation. Manage Issues + Projects v2 with AI-enforced INVEST quality, dependency tracking, and one-command execution.",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "author": {
     "name": "Filipe Utzig",
     "email": "filipe@gringolito.com"


### PR DESCRIPTION
Release prep for v0.6.0. Milestone: https://github.com/gringolito/github-backlog-management-skill/milestone/8.