### PR TITLE
feat: surface issue comments to executing agent via pick-item and execute-item

### DIFF
--- a/bin/pick-item
+++ b/bin/pick-item
@@ -248,10 +248,15 @@ if [[ -n "$winner_num" ]]; then
     }')
   } || parent_out="null"
 
+  # Comments fetch (cap at 100)
+  comments_raw=$(gh api "repos/${owner}/${repo}/issues/${winner_num}/comments?per_page=100" 2>/dev/null || echo "[]")
+  comments_out=$(echo "$comments_raw" | jq '[.[] | {author: .user.login, created_at, body}]')
+
   candidate_out=$(echo "$winner_item" | jq \
     --argjson tier "$winner_tier" \
     --argjson sub_issues_summary "$winner_sub_issues_summary" \
     --argjson parent "$parent_out" \
+    --argjson comments "$comments_out" \
     '{
       number:             .content.number,
       title:              .content.title,
@@ -261,7 +266,8 @@ if [[ -n "$winner_num" ]]; then
       milestone:          (.milestone | if . then {title: .title} else null end),
       url:                .content.url,
       sub_issues_summary: $sub_issues_summary,
-      parent:             $parent
+      parent:             $parent,
+      comments:           $comments
     }')
 
 else

--- a/skills/execute-item/SKILL.md
+++ b/skills/execute-item/SKILL.md
@@ -64,6 +64,22 @@ If `skipped_for_sub_issues` is non-empty, log each as: `Skipping parent #N — o
 
 If the picked item's `priority:*` label appears mismatched against its Project rank, surface the discrepancy so the user can confirm or reorder.
 
+#### 1.1 Issue Comment History
+
+If `candidate.comments` is non-empty, display the full comment thread before proceeding to Step 3:
+
+```
+**Comment history — #N: <title>** (<count> comments)
+
+@<author> · <created_at>
+<body>
+
+@<author> · <created_at>
+<body>
+```
+
+One block per comment, in chronological order. Skip this section entirely when `candidate.comments` is empty.
+
 ---
 
 ### 2. Per-Blocker Analysis Table


### PR DESCRIPTION
## Summary

- `bin/pick-item` fetches up to 100 comments for the selected (winner) issue via the GitHub API and includes them as `candidate.comments` in its JSON output, with each entry shaped as `{author, created_at, body}`
- `skills/execute-item/SKILL.md` gains a new Step 1.1 that instructs the executing agent to display the full comment thread when `candidate.comments` is non-empty, giving the agent the full recorded history of the item before INVEST validation and planning begin
- In-progress items carry no comment data and no comment display — skipped silently

## Acceptance Criteria Coverage

- [x] `bin/pick-item` fetches all comments for the selected issue using the GitHub API — implemented via `gh api "repos/.../issues/.../comments?per_page=100"`
- [x] `execute-item` includes comment content (author, body, timestamp) in the context provided to the executing agent — Step 1.1 instructs the agent to render the thread from `candidate.comments`
- [x] When an issue has no comments, the flow proceeds normally without error — Step 1.1 skips the block entirely when `candidate.comments` is empty
- [x] When an issue has comments, the executing agent demonstrably receives them — `candidate.comments` is populated by `pick-item` and displayed in Step 1.1 before any planning step

Closes #168