### PR TITLE
feat(skills): support custom type:* labels via runtime GitHub label discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ Every issue created by this skill follows a consistent body shape:
 Every backlog item carries three label groups:
 
 - **Type** — `type:feature` `type:bug` `type:security` `type:performance` `type:dx` `type:tech-debt` `type:reliability` `type:compliance` `type:spike`
+
+  Custom `type:*` labels are automatically discovered by `label-classifier` at runtime. No changes to the skill are required. For best accuracy, add a meaningful GitHub label description to each custom label; the description is used as "when to apply" guidance. Labels with no description fall back to a generic name-based rule. The `/audit` command flags any `type:*` label with a blank description.
+
 - **Priority** — `priority:P0` through `priority:P3`
 - **Effort** — `effort:XS` `effort:S` `effort:M` `effort:L` `effort:XL`
 

--- a/agents/backlog-auditor.md
+++ b/agents/backlog-auditor.md
@@ -24,6 +24,9 @@ Gather the audit dataset:
   - `gh project item-list <project-number> --owner <owner> --format json --limit 500 --query "is:issue -status:Done"`
 - Open milestones with `due_on`:
   - `gh api "repos/<owner>/<repo>/milestones?state=all"`
+- All `type:*` labels with their descriptions (for catalog hygiene):
+  - `gh label list --repo <owner>/<repo> --json name,description --limit 100 | jq '[.[] | select(.name | startswith("type:"))]'`
+  - For each label where `description` is empty or blank, flag as **Quality**: `type:* label "<name>" has no description — label-classifier will use a generic fallback. Fix: gh label edit "<name>" --repo <owner>/<repo> --description "..."`
 
 If structure is unclear or `gh` fails:
 
@@ -50,7 +53,7 @@ For EACH issue in the Project, first determine whether it is a `type:external-bl
 
 ##### Labels (exactly-one rule)
 
-- Exactly one `type:*` label from the canonical set (`type:feature`, `type:bug`, `type:security`, `type:performance`, `type:dx`, `type:tech-debt`, `type:reliability`, `type:compliance`, `type:spike`, `type:external-blocker`)
+- Exactly one `type:*` label from the set discovered in Step 1 (canonical labels plus any custom `type:*` labels present in the repository)
 - Exactly one `priority:*` label from {`priority:P0`, `priority:P1`, `priority:P2`, `priority:P3`}
 - Exactly one `effort:*` label from {`effort:XS`, `effort:S`, `effort:M`, `effort:L`, `effort:XL`}
 
@@ -58,7 +61,7 @@ Flag:
 
 - Missing required label group
 - Duplicate labels within a group (e.g. both `priority:P0` and `priority:P1`)
-- Unknown labels matching the pattern but not in the canonical set
+- `type:*` label not present in the repository's label catalog (use the Step 1 fetch as the source of truth)
 
 ##### Issue body sections
 
@@ -284,6 +287,7 @@ Produce a **Validation Report** with:
 - Stale blockers (blocker in closed milestone while item is in the Active Release)
 - `type:external-blocker` stub with missing, empty, or boilerplate Reason field
 - `type:external-blocker` stub that is open but blocking no issues (orphaned)
+- `type:*` labels with missing or blank GitHub description
 
 ### C. Consistency Issues
 

--- a/agents/label-classifier.md
+++ b/agents/label-classifier.md
@@ -18,6 +18,7 @@ You do NOT create, edit, or delete any files or issues. You only read the input 
 
 You receive one or more of the following:
 
+- **Repository** (required) — `<owner>/<repo>` of the target repository
 - **Issue title** (required) — the concise title of the backlog item
 - **Issue body** (required) — the full markdown body of the backlog item, expected to contain sections: `### What`, `### Why`, `### In Scope`, `### Out of Scope`, `### Acceptance Criteria`, `### INVEST Notes`
 - **Existing labels** (optional) — any labels already applied (e.g. `type:feature`, `priority:P1`, `effort:M`); treat as context, not as a constraint
@@ -45,6 +46,22 @@ Assign exactly ONE of the following. `type:external-blocker` is reserved for Stu
 If the item fits more than one type, choose the dominant one — the label that best captures the primary deliverable.
 
 If no single type clearly dominates, return `unclear: type — <reason>` instead of guessing.
+
+#### Custom Type Labels (Runtime Discovery)
+
+Before classifying, run:
+
+```sh
+gh label list --repo <owner>/<repo> --json name,description --limit 100 \
+  | jq '[.[] | select(.name | startswith("type:"))]'
+```
+
+If the command fails, return `unclear: type — label fetch failed: <error>` and stop.
+
+From the results, exclude any label whose `name` already appears in the table above. For each remaining label, append a row to the Type Labels table:
+
+- `description` non-empty → use the GitHub description as the "When to apply" guidance
+- `description` empty → use "Apply when the label name best describes the dominant deliverable"
 
 ### Priority Labels
 
@@ -110,7 +127,6 @@ effort:S — confined to a single package
 - Return ONLY the structured output — no explanation headers, no summaries, no preamble
 - NEVER assign `type:external-blocker` to a Workable Item — if the item is a Stub, return `unclear: type — item appears to be a Stub; use /add-external-blocker instead`
 - Do NOT suggest fixes to the issue body
-- Do NOT fetch any external data — evaluate only what is provided
 - Do NOT write or edit any files
 - If both the title and body are missing or empty: return all three lines as `unclear: <group> — no input provided`
 - Effort is NEVER measured in time (no hours/days)

--- a/skills/add-external-blocker/SKILL.md
+++ b/skills/add-external-blocker/SKILL.md
@@ -23,7 +23,7 @@ Create a lightweight stub issue (`type:external-blocker`) that represents an ext
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
 
 ---
 

--- a/skills/add-item/SKILL.md
+++ b/skills/add-item/SKILL.md
@@ -15,7 +15,7 @@ Your goal is to define, refine, prioritize, and add high-quality backlog items t
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
 
 ---
 
@@ -75,7 +75,7 @@ If `invest-gate` returns `Overall: FAIL`:
 
 Delegate classification to the `label-classifier` agent:
 
-- **Input**: the issue title and the body produced in step 2
+- **Input**: `owner`/`repo`, the issue title and the body produced in step 2
 - The agent returns a verdict for each of the three label groups (`type:*`, `priority:*`, `effort:*`) with one-line reasoning
 
 Handle the returned verdict:

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -23,17 +23,13 @@ Audit the backlog to confirm it meets all defined quality, consistency, and inte
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
 
 ---
 
 ### 1. Delegate Audit (MANDATORY)
 
-Spawn the `backlog-auditor` agent, passing:
-
-- `project_number` — from `.claude/backlog-project.json`
-- `owner` — from `.claude/backlog-project.json`
-- `repo` — from `.claude/backlog-project.json`
+Spawn the `backlog-auditor` agent, passing: `project_number`, `owner` and `repo`.
 
 ---
 

--- a/skills/block-item/SKILL.md
+++ b/skills/block-item/SKILL.md
@@ -21,7 +21,7 @@ Register a `blocked_by` dependency between two GitHub issues: mark issue `#N` as
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
 
 ---
 

--- a/skills/close-release/SKILL.md
+++ b/skills/close-release/SKILL.md
@@ -21,7 +21,7 @@ Close a GitHub Milestone cleanly: resolve every open issue interactively, satisf
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
 
 ---
 

--- a/skills/execute-item/SKILL.md
+++ b/skills/execute-item/SKILL.md
@@ -13,7 +13,7 @@ You are an AI agent acting as a development lead. Select and execute the topmost
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
 
 ---
 
@@ -195,6 +195,7 @@ Determine the Conventional Commits prefix from the issue's `type:*` label:
 - `type:dx` → `chore/`
 - `type:security`, `type:reliability`, `type:compliance` → `fix/` (security/correctness scope)
 - `type:spike` → `spike/`
+- Any other custom `type:*` label → use the label value as the prefix (e.g. `type:data-pipeline` → `data-pipeline/`); if the value contains `:`, strip it
 
 Branch name format: `<prefix>/<slug>` (e.g. `fix/null-pointer-in-authn`).
 

--- a/skills/github-backlog-management/SKILL.md
+++ b/skills/github-backlog-management/SKILL.md
@@ -43,7 +43,7 @@ Every Workable Item passes INVEST (Independent, Negotiable, Valuable, Estimable,
 ## Key Invariants (apply to all skills)
 
 **Label catalog**
-- `type:` — `feature` `bug` `security` `performance` `dx` `tech-debt` `reliability` `compliance` `spike` `external-blocker`
+- `type:` — `feature` `bug` `security` `performance` `dx` `tech-debt` `reliability` `compliance` `spike` `external-blocker` (plus any custom `type:*` labels present in the repository)
 - `priority:` — `P0` `P1` `P2` `P3`
 - `effort:` — `XS` `S` `M` `L` `XL`
 - Operational: `needs-clarification`

--- a/skills/health/SKILL.md
+++ b/skills/health/SKILL.md
@@ -23,7 +23,7 @@ Produce a Markdown strategic portfolio health report covering: open-issue distri
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
 
 ---
 
@@ -58,7 +58,7 @@ All computations operate on the pre-filtered open-issue set (stubs excluded). Us
 
 For each of the three label groups — `type:*`, `priority:*`, `effort:*` — in canonical order:
 
-- `type:*`: feature, bug, security, performance, dx, tech-debt, reliability, compliance, spike (omit values with 0 count)
+- `type:*`: use the discovered label list from `gh label list --repo <owner>/<repo> --json name --limit 100 | jq '[.[] | select(.name | startswith("type:")) | .name]'` as the value set; omit values with 0 count
 - `priority:*`: P0, P1, P2, P3
 - `effort:*`: XS, S, M, L, XL
 

--- a/skills/migrate/SKILL.md
+++ b/skills/migrate/SKILL.md
@@ -29,7 +29,7 @@ Transform ALL existing backlog items into GitHub Issues while:
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
 
 ---
 
@@ -96,7 +96,7 @@ If `invest-gate` returns `Overall: FAIL`:
 
 Delegate classification to the `label-classifier` agent:
 
-- **Input**: the normalized title and the body finalized in steps 3–4
+- **Input**: `owner`/`repo`, the normalized title and the body finalized in steps 3–4
 - The agent returns a verdict for each of the three label groups (`type:*`, `priority:*`, `effort:*`) with one-line reasoning
 
 Apply the returned verdicts:

--- a/skills/plan-release/SKILL.md
+++ b/skills/plan-release/SKILL.md
@@ -27,7 +27,7 @@ Either:
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
 
 ---
 

--- a/skills/refine-item/SKILL.md
+++ b/skills/refine-item/SKILL.md
@@ -30,7 +30,7 @@ Bring the target issue to a fully refined state where:
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
 
 ---
 
@@ -137,7 +137,7 @@ If INVEST passes (or partial — per step 5):
 
 Refinement frequently reveals different severity, effort, or type than `migrate` inferred. Delegate re-classification to the `label-classifier` agent:
 
-- **Input**: the refined issue title and the reconstructed body from step 4
+- **Input**: `owner`/`repo`, the refined issue title and the reconstructed body from step 4
 - The agent returns a verdict for each of the three label groups (`type:*`, `priority:*`, `effort:*`) with one-line reasoning
 
 Compare the agent's verdict against the currently applied labels and propose changes (independently for each group):

--- a/skills/refine/SKILL.md
+++ b/skills/refine/SKILL.md
@@ -21,7 +21,7 @@ Walk every selected item from two candidate pools — `needs-clarification` issu
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
 
 ---
 

--- a/skills/release-status/SKILL.md
+++ b/skills/release-status/SKILL.md
@@ -23,7 +23,7 @@ Produce a Markdown release health dashboard for a target milestone: issue counts
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
 
 ---
 

--- a/skills/resolve-external-blocker/SKILL.md
+++ b/skills/resolve-external-blocker/SKILL.md
@@ -21,7 +21,7 @@ Close an external-blocker stub issue (created by `/add-external-blocker`) with a
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, projectNumber, projectId, statusFieldId, statusOptions).
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
 
 ---
 


### PR DESCRIPTION
## Summary

- `label-classifier` fetches all `type:*` labels from the repository at runtime via `gh label list`, appending custom labels (not in the built-in rubric) with their GitHub description as "when to apply" guidance; blank-description labels fall back to a generic name-based rule
- `backlog-auditor` flags `type:*` labels with blank descriptions in Step 1, and its structural validation accepts the full discovered set instead of the hardcoded canonical list
- All callers (`add-item`, `migrate`, `refine-item`) now pass `owner`/`repo` from preflight output to `label-classifier`; `audit` skill passes the same from preflight to `backlog-auditor`
- `execute-item` adds a fallback branch-prefix rule for unrecognised custom types; `health` discovers type labels at runtime for its distribution table
- All skills corrected from camelCase to snake_case preflight field references (`projectNumber` → `project_number`, etc.)

## Acceptance Criteria

- [x] Standard `type:*` repos produce identical output — built-in rubric rows are preserved; only non-matching custom labels are appended
- [x] Custom `type:*` labels are included as valid options and can be assigned — discovered via runtime `gh label list` fetch
- [x] No source code changes required to support a new custom label — discovery is fully runtime
- [x] API failure surfaces `unclear: type — label fetch failed: <error>` — no silent hardcoded fallback
- [x] README documents custom `type:*` label support with guidance on adding descriptions

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)