### PR TITLE
refactor(skills): centralize preflight contract and issue-body sections

### DIFF
--- a/skills/add-external-blocker/SKILL.md
+++ b/skills/add-external-blocker/SKILL.md
@@ -23,7 +23,7 @@ Create a lightweight stub issue (`type:external-blocker`) that represents an ext
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
+Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
 
 ---
 

--- a/skills/add-item/SKILL.md
+++ b/skills/add-item/SKILL.md
@@ -15,7 +15,7 @@ Your goal is to define, refine, prioritize, and add high-quality backlog items t
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
+Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
 
 ---
 
@@ -44,7 +44,7 @@ Delegate body authoring to the `issue-body-author` agent:
 - **Mode**: `create`
 - **Input**: the title and all context gathered in step 1 (desired outcome, user/business impact, constraints, risks, edge cases, scope inclusions and exclusions, acceptance criteria, and classification notes)
 
-The agent returns a fully structured body with canonical sections in strict order: `### What` → `### Why` → `### In Scope` → `### Out of Scope` → `### Acceptance Criteria` → `### INVEST Notes`.
+The agent returns a fully structured body with canonical sections; read [../github-backlog-management/issue-body-sections.md](../github-backlog-management/issue-body-sections.md) for the exact headings and order.
 
 If the agent marks any section with `<!-- TODO: ... -->`, STOP and resolve those gaps with the user before proceeding to step 3.
 

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -23,7 +23,7 @@ Audit the backlog to confirm it meets all defined quality, consistency, and inte
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
+Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
 
 ---
 

--- a/skills/block-item/SKILL.md
+++ b/skills/block-item/SKILL.md
@@ -21,7 +21,7 @@ Register a `blocked_by` dependency between two GitHub issues: mark issue `#N` as
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
+Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
 
 ---
 

--- a/skills/close-release/SKILL.md
+++ b/skills/close-release/SKILL.md
@@ -21,7 +21,7 @@ Close a GitHub Milestone cleanly: resolve every open issue interactively, satisf
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
+Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
 
 ---
 

--- a/skills/execute-item/SKILL.md
+++ b/skills/execute-item/SKILL.md
@@ -13,7 +13,7 @@ You are an AI agent acting as a development lead. Select and execute the topmost
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
+Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
 
 ---
 

--- a/skills/github-backlog-management/SKILL.md
+++ b/skills/github-backlog-management/SKILL.md
@@ -48,12 +48,11 @@ Every Workable Item passes INVEST (Independent, Negotiable, Valuable, Estimable,
 - `effort:` — `XS` `S` `M` `L` `XL`
 - Operational: `needs-clarification`
 
-**Issue body sections** (exact headings, this order):
-`### What` · `### Why` · `### In Scope` · `### Out of Scope` · `### Acceptance Criteria` · `### INVEST Notes`
+**Issue body sections**: read [issue-body-sections.md](./issue-body-sections.md) for the canonical ordered headings.
 
-**Metadata file**: `.claude/backlog-project.json` — written by `initialize`, read directly by all other skills.
+**Standard preflight**: read [preflight-contract.md](./preflight-contract.md) for the preflight instruction.
 
-**Standard preflight**: all consumer skills run `backlog-preflight` (a shared executable by the plugin infrastructure) as Step 0. On success it emits the metadata JSON; on failure it prints the canonical stop string and exits non-zero. The canonical stop string is: `No Backlog project linked to <owner>/<repo>. Run /initialize first.`
+**Metadata file**: `.claude/backlog-project.json` — written by `initialize`, read during preflight.
 
 **Priority vs rank**: `priority:*` is severity classification. Project rank (topmost Todo item) is execution order. They should stay consistent but are independent concepts — `execute-item` sorts by rank only.
 

--- a/skills/github-backlog-management/issue-body-sections.md
+++ b/skills/github-backlog-management/issue-body-sections.md
@@ -1,0 +1,10 @@
+# Issue body sections
+
+The issue body must contains the following six sections (exact headings, this order):
+
+- `### What`
+- `### Why`
+- `### In Scope`
+- `### Out of Scope`
+- `### Acceptance Criteria`
+- `### INVEST Notes`

--- a/skills/github-backlog-management/preflight-contract.md
+++ b/skills/github-backlog-management/preflight-contract.md
@@ -1,0 +1,10 @@
+# Preflight contract
+
+Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout. This is the metadata used throughout the workflow:
+
+- `owner`
+- `repo`
+- `project_number`
+- `project_id`
+- `status_field_id`
+- `status_options`

--- a/skills/health/SKILL.md
+++ b/skills/health/SKILL.md
@@ -23,7 +23,7 @@ Produce a Markdown strategic portfolio health report covering: open-issue distri
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
+Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
 
 ---
 

--- a/skills/migrate/SKILL.md
+++ b/skills/migrate/SKILL.md
@@ -29,7 +29,7 @@ Transform ALL existing backlog items into GitHub Issues while:
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
+Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
 
 ---
 

--- a/skills/plan-release/SKILL.md
+++ b/skills/plan-release/SKILL.md
@@ -27,7 +27,7 @@ Either:
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
+Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
 
 ---
 

--- a/skills/refine-item/SKILL.md
+++ b/skills/refine-item/SKILL.md
@@ -30,7 +30,7 @@ Bring the target issue to a fully refined state where:
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
+Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
 
 ---
 
@@ -214,7 +214,7 @@ Before removing the `needs-clarification` label, re-fetch the current live state
 
 Run all of the following checks:
 
-- **Sections present** — all six body headings exist in exact order: `### What`, `### Why`, `### In Scope`, `### Out of Scope`, `### Acceptance Criteria`, `### INVEST Notes`
+- **Sections present** — all body headings exist in the exact order defined in [../github-backlog-management/issue-body-sections.md](../github-backlog-management/issue-body-sections.md)
 - **No stale markers** — no occurrences of `UNKNOWN`, `NEEDS CLARIFICATION`, or `_No response_` remain in any section
 - **Label completeness** — all three label groups are present: one `type:*`, one `priority:*`, one `effort:*`
 - **Project Status set** — the item has a non-empty Status value in the Project

--- a/skills/refine/SKILL.md
+++ b/skills/refine/SKILL.md
@@ -21,7 +21,7 @@ Walk every selected item from two candidate pools — `needs-clarification` issu
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
+Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
 
 ---
 

--- a/skills/release-status/SKILL.md
+++ b/skills/release-status/SKILL.md
@@ -23,7 +23,7 @@ Produce a Markdown release health dashboard for a target milestone: issue counts
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
+Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
 
 ---
 

--- a/skills/resolve-external-blocker/SKILL.md
+++ b/skills/resolve-external-blocker/SKILL.md
@@ -21,7 +21,7 @@ Close an external-blocker stub issue (created by `/add-external-blocker`) with a
 
 ### 0. Preflight (MANDATORY)
 
-Run `backlog-preflight` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON it prints to stdout — this is the metadata used throughout the workflow (owner, repo, project_number, project_id, status_field_id, status_options).
+Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
 
 ---
 


### PR DESCRIPTION
## Summary

- Extracts the preflight contract paragraph (duplicated verbatim across 13 consumer skills) into `skills/github-backlog-management/preflight-contract.md`
- Extracts the ordered issue-body section headings (duplicated in `add-item` and `refine-item`) into `skills/github-backlog-management/issue-body-sections.md`
- Replaces every duplicated block with a one-line imperative-read pointer to the canonical file
- Updates the dispatcher `github-backlog-management/SKILL.md` Key Invariants section to pointer-reference both new files

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)