### PR TITLE
refactor(skills): prefer gh project item-list over gh issue list

### DIFF
--- a/agents/backlog-auditor.md
+++ b/agents/backlog-auditor.md
@@ -167,8 +167,7 @@ Fetch all closed milestones: `gh api "repos/<owner>/<repo>/milestones?state=clos
 
 For each closed milestone, find open issues assigned to it that are also present in the linked Project:
 
-- `gh issue list --state open --milestone "<milestone-title>" --json number,title,url --limit 200`
-- Cross-reference against the Project item list already fetched in Step 1 (retain only issues that appear in the Project).
+- Filter the Step 1 project item-list result by `milestone.title` matching `<closed-milestone-title>`.
 
 If stale items are found, display them in "C. Consistency Issues" under a **Stale Milestone Items** heading:
 

--- a/skills/close-release/SKILL.md
+++ b/skills/close-release/SKILL.md
@@ -41,7 +41,7 @@ Display the resolved milestone title, number, `due_on`, and open/closed issue co
 
 Fetch all open issues assigned to the milestone:
 
-`gh issue list --state open --milestone "<milestone-title>" --json number,title,labels,url --limit 500`
+`gh project item-list <project-number> --owner <owner> --query "is:issue state:open milestone:<milestone-title>" --format json --limit 500`
 
 If there are no open issues, skip to Step 3.
 
@@ -85,7 +85,7 @@ If the call fails (e.g. no PRs merged), use an empty base draft and note the fai
 
 Fetch all closed issues from the milestone:
 
-`gh issue list --state closed --milestone "<milestone-title>" --json number,title,labels,body,url --limit 500`
+`gh project item-list <project-number> --owner <owner> --query "is:issue state:closed milestone:<milestone-title>" --format json --limit 500`
 
 Scan each closed issue's `### What` and `### INVEST Notes` body sections for signals worth surfacing in release notes:
 

--- a/skills/refine-item/SKILL.md
+++ b/skills/refine-item/SKILL.md
@@ -80,7 +80,7 @@ Reuse the discovery pattern from `add-item`:
 - Revisit the displayed relationships:
   - **Dependency scan**: delegate to the `dependency-inferrer` agent with:
     - **Prose**: the full issue body (all sections concatenated)
-    - **Issue roster**: the list of open issues in the Project (`gh issue list --state open --json number,title --limit 200 | jq -r '.[] | "#\(.number) \"\(.title)\""'`)
+    - **Issue roster**: the list of open issues in the Project (`gh project item-list <project-number> --owner <owner> --query "is:issue state:open" --format json --limit 200 | jq -r '.items[] | "#\(.content.number) \"\(.content.title)\""'`)
     If the agent returns any candidates, present them to the user as starting proposals for the relationship review. `UNRESOLVED` targets are surfaced as open questions for the user to clarify.
   - Are existing blockers still relevant? Should any be removed via `gh api -X DELETE "repos/<owner>/<repo>/issues/<n>/dependencies/blocked_by/<blocker-id>"`?
   - Did refinement reveal NEW blockers? (issue numbers; cross-repo allowed)

--- a/skills/release-status/SKILL.md
+++ b/skills/release-status/SKILL.md
@@ -41,21 +41,20 @@ Run `resolve-milestone "<argument>"` if an argument was provided, or `resolve-mi
 
 With the resolved milestone in hand, run these queries:
 
-1. **Issues assigned to the milestone**:
-   `gh issue list --state all --milestone "<milestone-title>" --json number,title,labels,state,url --limit 500`
+1. **Issues assigned to the milestone** (two queries — state is inferred from which query returned the item):
+   - Open: `gh project item-list <project-number> --owner <owner> --query "is:issue state:open milestone:<milestone-title>" --format json --limit 500`
+   - Closed: `gh project item-list <project-number> --owner <owner> --query "is:issue state:closed milestone:<milestone-title>" --format json --limit 500`
+
+   All returned items are Project members by definition. The `status` field (`Todo` / `In Progress` / `Done`) is available directly on each item.
 
    After fetching, **partition the results**: set aside any issue whose labels include `type:external-blocker` — these are Stubs and are **excluded from all Milestone counts and metrics**. They are retained only to enrich the blocked-items table with stub titles as blocker context (step 3).
 
-2. **Project membership and Status**:
-   `gh project item-list <project-number> --owner <owner> --query "is:issue milestone:<milestone-title>" --format json --limit 200`
-   Build a lookup map: issue `number` → Project `Status` (`Todo` / `In Progress` / `Done`). Issues absent from the map are classified as "Not in Project."
-
-3. **Blocker check** (open issues only):
+2. **Blocker check** (open issues only):
    For each open issue, call: `gh api "repos/<owner>/<repo>/issues/<n>/dependencies/blocked_by"`
    - If the API returns `404` on the first call, emit exactly once: `Issue Dependencies API unavailable on this repo — blocked items section omitted.` Skip the blocked-items section for the entire report.
    - An issue is **blocked** if the response contains at least one blocker with `state == "open"`.
 
-4. **Unestimated check**:
+3. **Unestimated check**:
    For each issue, scan its labels for any `effort:*` label. Issues with none are unestimated.
 
 ---
@@ -80,10 +79,8 @@ Omit the `Due:` line if the milestone has no `due_on`.
 | ✅ Done | N | N% |
 | 🔄 In Progress | N | N% |
 | 📋 Todo | N | N% |
-| ⚠️ Not in Project | N | — |
 
 - **% complete** = Done ÷ (all non-stub issues assigned to the milestone), rounded to the nearest integer. `type:external-blocker` stubs are excluded from this denominator.
-- Omit the "Not in Project" row if its count is 0.
 
 #### Blocked Items
 
@@ -122,9 +119,6 @@ Issues grouped by Status:
 **📋 Todo (N)**
 - [ ] [#N](\<url\>) — title
 
-**⚠️ Not in Project (N)** _(omit section if 0)_
-- [ ] [#N](\<url\>) — title
-
 ---
 
 ## Rules & Constraints
@@ -132,7 +126,7 @@ Issues grouped by Status:
 - This skill is **strictly read-only** — never mutate any issue, Project field, milestone, or label.
 - Surface all `gh` errors verbatim — never swallow.
 - Issue Dependencies API `404` must emit one warning line and gracefully skip the blocked-items section; it must not abort the rest of the report.
-- % complete is always computed over ALL issues assigned to the milestone, not just those in the Project.
+- % complete is computed over all non-stub issues returned by the project queries.
 - Do NOT pick or recommend execution order — this skill surfaces state only.
 
 ---


### PR DESCRIPTION
## Summary

- Migrates 5 `gh issue list` calls across `backlog-auditor`, `release-status`, `close-release`, and `refine-item` to `gh project item-list` with server-side filters
- `release-status` now runs two project queries (`state:open` / `state:closed`) instead of one issue list + one project list; the "Not in Project" row/section is removed since all returned items are project members by definition
- `backlog-auditor` stale-milestone check now filters the Step 1 result in-memory instead of making per-milestone API calls
- `refine-item` dependency-inferrer roster updated to use `.items[].content.number/title` jq path

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)