### PR TITLE
feat(labels): introduce type:epic for umbrella items

### DIFF
--- a/agents/backlog-auditor.md
+++ b/agents/backlog-auditor.md
@@ -235,7 +235,8 @@ For each `type:external-blocker` stub in the Project:
 
 - **Sub-issue parent not in Project** — child is in the Project but its parent isn't. Flag as Consistency. The parent should usually be in the Project too (epic-level visibility).
 - **Sub-issue with explicit milestone different from parent's milestone** — informational only. Sub-issues stay independent by design (no milestone inheritance), but a divergence is worth surfacing in case it's accidental.
-- **Parent issue with no sub-issues but type is `type:spike`** — informational. Spikes that were broken down should still hold their children.
+- **Parent issue with no sub-issues and `type:epic`** — **Quality**: a childless epic has not been groomed. Flag as: `Epic #N has no sub-issues — not yet decomposed`. Provide remediation: `gh issue edit <n> --add-label "needs-clarification"`.
+- **Parent issue with no sub-issues and `type:spike`** — informational. Spikes that were broken down should still hold their children.
 
 ---
 

--- a/agents/invest-gate.md
+++ b/agents/invest-gate.md
@@ -24,6 +24,16 @@ You receive one or more of the following:
 
 ---
 
+## Type-specific Exemptions
+
+If the item carries `type:epic` in its labels:
+
+- **S**: return `PASS — S: exempt; epic decomposes into sub-issues by design`
+- **T**: return `PASS — T: exempt; acceptance criteria are verified at the sub-issue level`
+- Evaluate I, N, V, E normally.
+
+---
+
 ## INVEST Rubric
 
 | Letter | Criterion | Definition |
@@ -32,7 +42,7 @@ You receive one or more of the following:
 | **N** | Negotiable | The item describes WHAT is needed, not HOW to implement it. Hard-wired technology choices, specific file names, or mandatory code patterns are violations unless they are themselves the acceptance criteria (e.g. a migration to a specific library). |
 | **V** | Valuable | The item delivers a clear, stated benefit to a user, the system, or the business. Internal work (refactors, debt cleanup) is valuable if `### Why` explains the benefit explicitly. An empty or `_No response_` `### Why` is a violation. |
 | **E** | Estimable | The `### In Scope`, `### Acceptance Criteria`, and `### What` sections together contain enough detail for a developer to form a complexity estimate. `UNKNOWN`, `NEEDS CLARIFICATION`, or `_No response_` in any required section is a violation. |
-| **S** | Small | The item can be delivered in a single iteration. Signs it is too large: more than ~5 acceptance criteria, or criteria that imply multiple independent deliverables. |
+| **S** | Small | The item can be delivered in a single iteration. Signs it is too large: too many acceptance criteria, or criteria that imply multiple independent deliverables. |
 | **T** | Testable | Each criterion in `### Acceptance Criteria` must be objectively verifiable by a third party. Vague criteria ("works correctly", "improves performance", "is better") are violations. |
 
 ---

--- a/agents/label-classifier.md
+++ b/agents/label-classifier.md
@@ -42,6 +42,7 @@ Assign exactly ONE of the following. `type:external-blocker` is reserved for Stu
 | `type:reliability` | Uptime, error recovery, observability, or graceful-degradation improvement |
 | `type:compliance` | Regulatory, legal, or contractual obligation |
 | `type:spike` | Time-boxed research or proof-of-concept to reduce uncertainty |
+| `type:epic` | A large, high-level body of work that is too big to complete in a single iteration or is large enough that it can be split into multiple sub-issues |
 
 If the item fits more than one type, choose the dominant one — the label that best captures the primary deliverable.
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -4,7 +4,7 @@ This repo uses the `github-backlog-management-skill`'s own label classification 
 
 ## Label catalog
 
-- **Type**: `type:feature`, `type:bug`, `type:security`, `type:performance`, `type:dx`, `type:tech-debt`, `type:reliability`, `type:compliance`, `type:spike`, `type:external-blocker`
+- **Type**: `type:feature`, `type:bug`, `type:security`, `type:performance`, `type:dx`, `type:tech-debt`, `type:reliability`, `type:compliance`, `type:spike`, `type:epic`, `type:external-blocker`
 - **Priority**: `priority:P0`, `priority:P1`, `priority:P2`, `priority:P3`
 - **Effort**: `effort:XS`, `effort:S`, `effort:M`, `effort:L`, `effort:XL`
 - **Special**: `needs-clarification`

--- a/skills/add-item/SKILL.md
+++ b/skills/add-item/SKILL.md
@@ -80,7 +80,7 @@ Delegate classification to the `label-classifier` agent:
 
 Handle the returned verdict:
 
-- `type:*` — if the agent returns `unclear: type`, STOP and use AskUserQuestion, offering the 3–4 most contextually likely types as options (choose from: `feature`, `bug`, `security`, `performance`, `dx`, `tech-debt`, `reliability`, `compliance`, `spike`, `external-blocker`); "Other" is automatically provided for anything not listed
+- `type:*` — if the agent returns `unclear: type`, STOP and use AskUserQuestion, offering the 3–4 most contextually likely types as options (choose from: `feature`, `bug`, `security`, `performance`, `dx`, `tech-debt`, `reliability`, `compliance`, `spike`, `epic`, `external-blocker`); "Other" is automatically provided for anything not listed
 - `priority:*` — if the agent returns `unclear: priority`, present the reasoning and use AskUserQuestion with options: `P0` / `P1` / `P2` / `P3`; default to `priority:P2` only if the user explicitly selects it
 - `effort:*` — if the agent returns `unclear: effort`, present the reasoning and use AskUserQuestion with the 4 most contextually relevant sizes as options (from `XS`, `S`, `M`, `L`, `XL`); "Other" is automatically provided for the fifth
 

--- a/skills/execute-item/SKILL.md
+++ b/skills/execute-item/SKILL.md
@@ -81,9 +81,13 @@ One block per comment, in chronological order. Skip this section entirely when `
 Use `candidate.sub_issues_summary` from the script output — no API call needed.
 
 - **If `completed == total AND total > 0`:** All sub-issues are closed: read [scope-completeness.md](./scope-completeness.md) for the full review protocol. Then STOP.
-- **Otherwise:** proceed to Step 3.
+- **Otherwise:** proceed to Step 4.
 
 Note: Open sub-issue routing is already handled by `pick-item` — if the script selected a sub-issue as `candidate`, no further parent/sub-issue traversal is needed here.
+
+#### type:epic Gate
+
+If `candidate.labels` includes `type:epic` AND the item did not enter Scope Completeness Review above: STOP and tell the user to decompose the epic into sub-issues or add them into the project.
 
 ---
 

--- a/skills/github-backlog-management/SKILL.md
+++ b/skills/github-backlog-management/SKILL.md
@@ -43,7 +43,7 @@ Every Workable Item passes INVEST (Independent, Negotiable, Valuable, Estimable,
 ## Key Invariants (apply to all skills)
 
 **Label catalog**
-- `type:` — `feature` `bug` `security` `performance` `dx` `tech-debt` `reliability` `compliance` `spike` `external-blocker` (plus any custom `type:*` labels present in the repository)
+- `type:` — `feature` `bug` `security` `performance` `dx` `tech-debt` `reliability` `compliance` `spike` `epic` `external-blocker` (plus any custom `type:*` labels present in the repository)
 - `priority:` — `P0` `P1` `P2` `P3`
 - `effort:` — `XS` `S` `M` `L` `XL`
 - Operational: `needs-clarification`

--- a/skills/initialize/SKILL.md
+++ b/skills/initialize/SKILL.md
@@ -103,6 +103,7 @@ Create the standard label catalog. Use `gh label create --force` so existing lab
 - `type:reliability` — `"Uptime, error recovery, observability, or graceful-degradation improvement"`
 - `type:compliance` — `"Regulatory, legal, or contractual obligation"`
 - `type:spike` — `"Time-boxed investigation to reduce uncertainty; deliverable is knowledge"`
+- `type:epic` — `"A large, high-level body of work that is too big to complete in a single iteration or is large enough that it can be split into multiple sub-issues"`
 - `type:external-blocker` — `"External constraint blocking a backlog item (Stub)"`
 
 #### Priority labels (one of these must be on every backlog item)


### PR DESCRIPTION
## Summary

Introduces `type:epic` as a first-class label for umbrella/parent items that decompose into sub-issues and are not directly executable.

### Changes by acceptance criterion

| AC | Change |
|----|--------|
| `type:epic` in catalog + consistency check | `skills/initialize/SKILL.md`: label added after `type:spike`; `skills/github-backlog-management/SKILL.md`, `docs/agents/triage-labels.md`, `skills/add-item/SKILL.md`: `epic` added to every type enumeration |
| `initialize` provisions it on bootstrap | `skills/initialize/SKILL.md`: label definition included in Step 3 provisioning list |
| `label-classifier` assigns `type:epic` | `agents/label-classifier.md`: `type:epic` row added to Type Labels table with "not directly executable" guidance |
| `execute-item` never executes a `type:epic` | `skills/execute-item/SKILL.md`: `type:epic` gate added in Step 3 with targeted STOP per state (no sub-issues / open subs not in Todo queue) — epics with all subs closed still reach Scope Completeness Review |
| `validate-backlog` flags childless `type:epic` | `agents/backlog-auditor.md`: Quality flag for `type:epic` with no sub-issues, with `gh issue edit <n> --add-label "needs-clarification"` remediation snippet |

**Bonus:** `agents/invest-gate.md` gains a Type-specific Exemptions section that auto-passes S and T for `type:epic` items, preventing false Quality noise in every `/audit` run.

Closes #117