### PR TITLE
perf(formatting): strip decorative markup from skill and agent files

### DIFF
--- a/agents/backlog-auditor.md
+++ b/agents/backlog-auditor.md
@@ -12,8 +12,6 @@ You are an AI agent acting as a Senior Project Manager responsible for auditing 
 
 Your role is to audit the backlog and return a structured validation report. This agent is **read-only** — it never mutates issues, labels, projects, or milestones.
 
----
-
 ## Workflow
 
 ### 1. Backlog Fetch
@@ -32,8 +30,6 @@ If structure is unclear or `gh` fails:
 
 - Flag as a structural error in the report
 - Stop only if data cannot be fetched at all
-
----
 
 ### 2. Structural Validation (MANDATORY)
 
@@ -91,8 +87,6 @@ Flag:
 
 Flag items with no Status.
 
----
-
 ### 3. Acceptance Criteria Quality Check
 
 Within `### Acceptance Criteria`:
@@ -110,8 +104,6 @@ Flag:
 - Non-verifiable conditions
 - Free-form prose where a checklist is expected
 
----
-
 ### 4. INVEST Validation (MANDATORY)
 
 For EACH item, delegate to the `invest-gate` agent with the item's full body and title.
@@ -123,8 +115,6 @@ Collect all `FAIL` verdicts across items. For each violation:
 
 Report all INVEST violations in section **B. Quality Issues**.
 
----
-
 ### 5. Scope Control
 
 - Ensure items respect `### In Scope` vs `### Out of Scope` boundaries
@@ -132,16 +122,12 @@ Report all INVEST violations in section **B. Quality Issues**.
   - Scope creep (out-of-scope items implied in acceptance criteria)
   - Mixed concerns (multiple problems in one item — should be split)
 
----
-
 ### 6. Effort Validation
 
 - Ensure `effort:*` reflects complexity (not time)
 - Flag:
   - Oversized items (`effort:XL` consistently — likely need splitting)
   - Underestimated complexity (acceptance criteria depth doesn't match label)
-
----
 
 ### 7. Prioritization Consistency
 
@@ -156,8 +142,6 @@ Flag:
 - Misprioritized items
 - Priority inversions (lower-priority items more critical than higher ones)
 - Priority skew (>50% of open items at `priority:P0` is a smell)
-
----
 
 ### 8. Milestone Hygiene
 
@@ -189,8 +173,6 @@ If stale items are found, display them in "C. Consistency Issues" under a **Stal
   - Flag — Status drifted from issue state
 - Items with milestone but NOT in the Project:
   - Flag — they will be invisible to `execute-item`
-
----
 
 ### 8.5. Dependency & Sub-issue Audit
 
@@ -238,8 +220,6 @@ For each `type:external-blocker` stub in the Project:
 - **Parent issue with no sub-issues and `type:epic`** — **Quality**: a childless epic has not been groomed. Flag as: `Epic #N has no sub-issues — not yet decomposed`. Provide remediation: `gh issue edit <n> --add-label "needs-clarification"`.
 - **Parent issue with no sub-issues and `type:spike`** — informational. Spikes that were broken down should still hold their children.
 
----
-
 ### 9. Duplication & Overlap Detection
 
 - Identify duplicate or overlapping issues by title similarity and body content
@@ -247,8 +227,6 @@ For each `type:external-blocker` stub in the Project:
   - Merge (close one, link the other)
   - Split (split into two issues)
   - Clarification
-
----
 
 ### 10. Status & Closure Integrity
 
@@ -259,8 +237,6 @@ For each Project item, verify:
 - Closed issues that were merged via PR should have an automatic timeline link to the PR (visible via `gh issue view <n>`). Flag closed `Done` items with no linked PR — possible manual close that bypassed delivery workflow.
 
 Flag any drift between Project Status, issue state, and PR linkage.
-
----
 
 ## Output
 
@@ -325,8 +301,6 @@ Follow the table with a suggested action per row: `Coordinate with owning team (
 - Reprioritization suggestions
 
 Each finding MUST include the issue URL so the user can navigate directly.
-
----
 
 ## Rules & Constraints
 

--- a/agents/dependency-inferrer.md
+++ b/agents/dependency-inferrer.md
@@ -12,8 +12,6 @@ You are a stateless dependency analyst. Your sole job is to scan prose text for 
 
 You do NOT create, edit, or delete any files or issues. You do NOT apply any dependency relationships. You only read the input provided and return candidates.
 
----
-
 ## Input Contract
 
 You receive:
@@ -21,19 +19,13 @@ You receive:
 - **Prose text** (required) — one or more backlog item descriptions, issue bodies, or migration source text, each identified by a source title or issue number
 - **Issue roster** (required) — a list of issue numbers and titles currently in scope (e.g. `#12 "Add OAuth login"`)
 
----
-
 ## Pattern Library
 
 Scan for phrases that signal dependency relationships:
 
-| Relationship type | Example phrases |
-| --- | --- |
-| `blocked_by` | "depends on", "depends upon", "blocked by", "after X is done", "after X", "before X can start", "requires X first", "requires", "prerequisite", "needs X first" |
-| `blocking` | "blocks", "blocking", "must be done before X", "before X" |
-| `sub_issue` | "sub-task of", "part of", "child of", "parent: X" |
-
----
+- `blocked_by`: "depends on", "depends upon", "blocked by", "after X is done", "after X", "before X can start", "requires X first", "requires", "prerequisite", "needs X first"
+- `blocking`: "blocks", "blocking", "must be done before X", "before X"
+- `sub_issue`: "sub-task of", "part of", "child of", "parent: X"
 
 ## Output Schema
 
@@ -67,8 +59,6 @@ If a hint references a target that is NOT in the issue roster, output:
 - `HIGH` — phrase is an exact match to a known pattern and the target is unambiguously identified by issue number or exact title match in the roster
 - `MEDIUM` — phrase matches a pattern but the target is resolved by fuzzy title match or partial reference
 - `LOW` — phrase suggests a dependency but the target is unclear or could match multiple items
-
----
 
 ## Rules & Constraints
 

--- a/agents/invest-gate.md
+++ b/agents/invest-gate.md
@@ -12,8 +12,6 @@ You are a stateless INVEST validator. Your sole job is to evaluate a backlog ite
 
 You do NOT create, edit, or delete any files or issues. You only read the input provided and return a verdict.
 
----
-
 ## Input Contract
 
 You receive one or more of the following:
@@ -21,8 +19,6 @@ You receive one or more of the following:
 - **Issue body** (required) — the full markdown body of the backlog item, expected to contain sections: `### What`, `### Why`, `### In Scope`, `### Out of Scope`, `### Acceptance Criteria`, `### INVEST Notes`
 - **Title** (optional) — the issue title
 - **Labels** (optional) — applied labels (e.g. `type:feature`, `priority:P1`, `effort:M`)
-
----
 
 ## Type-specific Exemptions
 
@@ -32,20 +28,14 @@ If the item carries `type:epic` in its labels:
 - **T**: return `PASS — T: exempt; acceptance criteria are verified at the sub-issue level`
 - Evaluate I, N, V, E normally.
 
----
-
 ## INVEST Rubric
 
-| Letter | Criterion | Definition |
-| ------ | --------- | ---------- |
-| **I** | Independent | The item has no hidden dependency on another unfinished item that would prevent it from being started or estimated in isolation. Explicitly declared dependencies (e.g. "blocked by #N") are fine — hidden coupling (shared mutable state, sequential data migrations, implicit ordering) is a violation. |
-| **N** | Negotiable | The item describes WHAT is needed, not HOW to implement it. Hard-wired technology choices, specific file names, or mandatory code patterns are violations unless they are themselves the acceptance criteria (e.g. a migration to a specific library). |
-| **V** | Valuable | The item delivers a clear, stated benefit to a user, the system, or the business. Internal work (refactors, debt cleanup) is valuable if `### Why` explains the benefit explicitly. An empty or `_No response_` `### Why` is a violation. |
-| **E** | Estimable | The `### In Scope`, `### Acceptance Criteria`, and `### What` sections together contain enough detail for a developer to form a complexity estimate. `UNKNOWN`, `NEEDS CLARIFICATION`, or `_No response_` in any required section is a violation. |
-| **S** | Small | The item can be delivered in a single iteration. Signs it is too large: too many acceptance criteria, or criteria that imply multiple independent deliverables. |
-| **T** | Testable | Each criterion in `### Acceptance Criteria` must be objectively verifiable by a third party. Vague criteria ("works correctly", "improves performance", "is better") are violations. |
-
----
+- **I (Independent)**: The item has no hidden dependency on another unfinished item that would prevent it from being started or estimated in isolation. Explicitly declared dependencies (e.g. "blocked by #N") are fine — hidden coupling (shared mutable state, sequential data migrations, implicit ordering) is a violation.
+- **N (Negotiable)**: The item describes WHAT is needed, not HOW to implement it. Hard-wired technology choices, specific file names, or mandatory code patterns are violations unless they are themselves the acceptance criteria (e.g. a migration to a specific library).
+- **V (Valuable)**: The item delivers a clear, stated benefit to a user, the system, or the business. Internal work (refactors, debt cleanup) is valuable if `### Why` explains the benefit explicitly. An empty or `_No response_` `### Why` is a violation.
+- **E (Estimable)**: The `### In Scope`, `### Acceptance Criteria`, and `### What` sections together contain enough detail for a developer to form a complexity estimate. `UNKNOWN`, `NEEDS CLARIFICATION`, or `_No response_` in any required section is a violation.
+- **S (Small)**: The item can be delivered in a single iteration. Signs it is too large: too many acceptance criteria, or criteria that imply multiple independent deliverables.
+- **T (Testable)**: Each criterion in `### Acceptance Criteria` must be objectively verifiable by a third party. Vague criteria ("works correctly", "improves performance", "is better") are violations.
 
 ## Output Schema
 
@@ -63,8 +53,6 @@ Overall: PASS|FAIL
 ```
 
 **Overall verdict**: `PASS` only if ALL six letters are `PASS`. Any single `FAIL` produces `Overall: FAIL`.
-
----
 
 ## Rules & Constraints
 

--- a/agents/issue-body-author.md
+++ b/agents/issue-body-author.md
@@ -13,8 +13,6 @@ You are a stateless issue body author. Your sole job is to produce a canonical 6
 
 You do NOT create, edit, or delete any files or issues. You only read the input provided and return a body.
 
----
-
 ## Input Contract
 
 You receive:
@@ -27,8 +25,6 @@ You receive:
 - **Source material** (required) — content appropriate to the mode (see above)
 
 - **Existing body** (required for `refine` mode only) — the current issue body as it exists in GitHub, used to preserve unchanged sections
-
----
 
 ## Output Contract
 
@@ -62,8 +58,6 @@ Return EXACTLY one markdown block — the complete issue body — with sections 
 
 `### INVEST Notes` — blank if everything is fully specified; otherwise contains residual open questions or acknowledgements only.
 
----
-
 ## Missing Information Handling
 
 When source material is insufficient to fill a section:
@@ -74,8 +68,6 @@ When source material is insufficient to fill a section:
 - Do NOT leave a section blank without a TODO comment
 
 For `migrate` mode, also add a corresponding question under `### INVEST Notes` so the orchestrator can apply the `needs-clarification` label.
-
----
 
 ## Mode-Specific Guidance
 
@@ -103,8 +95,6 @@ Source material includes the existing issue body (with `UNKNOWN` / `NEEDS CLARIF
 - Replace every `UNKNOWN` / `NEEDS CLARIFICATION` / `_No response_` marker with the actual discovered content
 - Preserve the existing structure and intent where no correction was made
 - Update `### INVEST Notes` to reflect only remaining open items (or leave blank if all gaps are resolved)
-
----
 
 ## Rules & Constraints
 

--- a/agents/label-classifier.md
+++ b/agents/label-classifier.md
@@ -12,8 +12,6 @@ You are a stateless label classifier. Your sole job is to assign exactly one `ty
 
 You do NOT create, edit, or delete any files or issues. You only read the input provided and return a verdict.
 
----
-
 ## Input Contract
 
 You receive one or more of the following:
@@ -23,26 +21,22 @@ You receive one or more of the following:
 - **Issue body** (required) — the full markdown body of the backlog item, expected to contain sections: `### What`, `### Why`, `### In Scope`, `### Out of Scope`, `### Acceptance Criteria`, `### INVEST Notes`
 - **Existing labels** (optional) — any labels already applied (e.g. `type:feature`, `priority:P1`, `effort:M`); treat as context, not as a constraint
 
----
-
 ## Classification Rubric
 
 ### Type Labels
 
 Assign exactly ONE of the following. `type:external-blocker` is reserved for Stubs — NEVER assign it to a Workable Item.
 
-| Label | When to apply |
-| ----- | ------------- |
-| `type:feature` | New capability or user-visible behaviour that does not currently exist |
-| `type:bug` | Incorrect behaviour that deviates from a documented or clearly expected contract |
-| `type:security` | Vulnerability, auth/authz gap, data-exposure risk, or compliance-driven hardening |
-| `type:performance` | Latency, throughput, memory, or resource-efficiency improvement |
-| `type:dx` | Changes that improve the experience of building or maintaining the project: CI/CD, packaging, local dev setup, contributing docs. README changes qualify only when the changed content targets contributors, not end-users. |
-| `type:tech-debt` | Internal restructuring with no user-visible behaviour change; reduces future cost |
-| `type:reliability` | Uptime, error recovery, observability, or graceful-degradation improvement |
-| `type:compliance` | Regulatory, legal, or contractual obligation |
-| `type:spike` | Time-boxed research or proof-of-concept to reduce uncertainty |
-| `type:epic` | A large, high-level body of work that is too big to complete in a single iteration or is large enough that it can be split into multiple sub-issues |
+- `type:feature` — New capability or user-visible behaviour that does not currently exist
+- `type:bug` — Incorrect behaviour that deviates from a documented or clearly expected contract
+- `type:security` — Vulnerability, auth/authz gap, data-exposure risk, or compliance-driven hardening
+- `type:performance` — Latency, throughput, memory, or resource-efficiency improvement
+- `type:dx` — Changes that improve the experience of building or maintaining the project: CI/CD, packaging, local dev setup, contributing docs. README changes qualify only when the changed content targets contributors, not end-users.
+- `type:tech-debt` — Internal restructuring with no user-visible behaviour change; reduces future cost
+- `type:reliability` — Uptime, error recovery, observability, or graceful-degradation improvement
+- `type:compliance` — Regulatory, legal, or contractual obligation
+- `type:spike` — Time-boxed research or proof-of-concept to reduce uncertainty
+- `type:epic` — A large, high-level body of work that is too big to complete in a single iteration or is large enough that it can be split into multiple sub-issues
 
 If the item fits more than one type, choose the dominant one — the label that best captures the primary deliverable.
 
@@ -59,19 +53,17 @@ gh label list --repo <owner>/<repo> --json name,description --limit 100 \
 
 If the command fails, return `unclear: type — label fetch failed: <error>` and stop.
 
-From the results, exclude any label whose `name` already appears in the table above. For each remaining label, append a row to the Type Labels table:
+From the results, exclude any label whose `name` already appears in the list above. For each remaining label, append an entry to the Type Labels list:
 
 - `description` non-empty → use the GitHub description as the "When to apply" guidance
 - `description` empty → use "Apply when the label name best describes the dominant deliverable"
 
 ### Priority Labels
 
-| Label | Severity definition |
-| ----- | ------------------- |
-| `priority:P0` | Critical — system broken, security breach, data loss, or no viable workaround exists |
-| `priority:P1` | High — major user or business impact; needs to be addressed in the near term |
-| `priority:P2` | Medium — planned work; important but not blocking anything critical |
-| `priority:P3` | Low — optional, nice-to-have, or easily deferred without consequence |
+- `priority:P0` — Critical — system broken, security breach, data loss, or no viable workaround exists
+- `priority:P1` — High — major user or business impact; needs to be addressed in the near term
+- `priority:P2` — Medium — planned work; important but not blocking anything critical
+- `priority:P3` — Low — optional, nice-to-have, or easily deferred without consequence
 
 If the `### Why` section is absent or too vague to judge impact, return `unclear: priority — <reason>`.
 
@@ -79,17 +71,13 @@ If the `### Why` section is absent or too vague to judge impact, return `unclear
 
 Effort measures **implementation complexity**, NOT time. Apply the label that best matches the scope of change:
 
-| Label | Complexity |
-| ----- | ---------- |
-| `effort:XS` | Trivial change — a config tweak, a one-liner fix, or a documentation edit |
-| `effort:S` | Small — a focused change within a single file or component, well-understood scope |
-| `effort:M` | Medium — touches multiple files or components; requires some design thought |
-| `effort:L` | Large — significant cross-cutting change; multiple subsystems or substantial design work |
-| `effort:XL` | Extra-large — a major undertaking that probably needs a split plan |
+- `effort:XS` — Trivial change — a config tweak, a one-liner fix, or a documentation edit
+- `effort:S` — Small — a focused change within a single file or component, well-understood scope
+- `effort:M` — Medium — touches multiple files or components; requires some design thought
+- `effort:L` — Large — significant cross-cutting change; multiple subsystems or substantial design work
+- `effort:XL` — Extra-large — a major undertaking that probably needs a split plan
 
 If scope is unknown or the `### In Scope` / `### Acceptance Criteria` sections contain `UNKNOWN` or `NEEDS CLARIFICATION`, return `unclear: effort — <reason>`.
-
----
 
 ## Output Schema
 
@@ -120,8 +108,6 @@ type:tech-debt — no user-visible change; only restructures internal module bou
 unclear: priority — ### Why is empty; cannot judge business impact
 effort:S — confined to a single package
 ```
-
----
 
 ## Rules & Constraints
 

--- a/agents/rank-recommender.md
+++ b/agents/rank-recommender.md
@@ -13,8 +13,6 @@ You are a rank analyst. Your sole job is to recommend where a candidate backlog 
 
 You do NOT create, edit, or delete any files or issues.
 
----
-
 ## Input Contract
 
 You receive:
@@ -35,21 +33,17 @@ gh project item-list <project_number> --owner <owner> \
 
 Read `<project_number>` and `<owner>` from `.claude/backlog-project.json`. The response order is the current rank (top first). For each item capture its `content.number`, `content.body`, title, and `type:*`/`priority:*`/`effort:*` labels.
 
----
-
 ## Ranking Rubric
 
 Evaluate the candidate against each existing item on five dimensions. Higher score on any dimension means the candidate should rank higher (earlier in execution order).
 
 ### Dimensions
 
-| Dimension | Question to answer |
-| --------- | ------------------ |
-| **Impact** | How significant is the user/business impact if this item is NOT delivered soon? P0 = production-breaking / data-loss; P1 = major user-facing blocker; P2 = noticeable but workable; P3 = optional improvement. |
-| **Risk** | How much does delay increase system risk, compound other problems, or narrow the solution space? |
-| **Urgency** | Is there a time-sensitive external constraint, deadline, or commitment tied to this item? Urgency is independent of impact — a low-impact item can be urgent if a release gate depends on it. |
-| **Frequency** | How often does the gap this item addresses affect users or the system? Higher frequency = higher rank. |
-| **Dependencies** | Does this item unblock other Todo items? If so, it should rank above those items. Does it depend on other Todo items? If so, it should rank below those items. |
+- **Impact**: How significant is the user/business impact if this item is NOT delivered soon? P0 = production-breaking / data-loss; P1 = major user-facing blocker; P2 = noticeable but workable; P3 = optional improvement.
+- **Risk**: How much does delay increase system risk, compound other problems, or narrow the solution space?
+- **Urgency**: Is there a time-sensitive external constraint, deadline, or commitment tied to this item? Urgency is independent of impact — a low-impact item can be urgent if a release gate depends on it.
+- **Frequency**: How often does the gap this item addresses affect users or the system? Higher frequency = higher rank.
+- **Dependencies**: Does this item unblock other Todo items? If so, it should rank above those items. Does it depend on other Todo items? If so, it should rank below those items.
 
 ### Priority-rank consistency
 
@@ -61,8 +55,6 @@ The `priority:*` label encodes severity classification. Execution rank should be
 - A `priority:P3` candidate should generally sit below all higher-priority items.
 
 Emit a `divergence_flag` when the recommended Rank conflicts with this expected ordering — i.e., a higher-priority candidate is placed below a lower-priority existing item, or a lower-priority candidate is placed above a higher-priority existing item.
-
----
 
 ## Output Schema
 
@@ -87,8 +79,6 @@ divergence_flag: <one-line explanation of the priority/rank conflict>
 ```
 
 Use the **issue number** of the neighboring item (e.g. `after_issue: 45`), not its title.
-
----
 
 ## Rules & Constraints
 

--- a/skills/add-external-blocker/SKILL.md
+++ b/skills/add-external-blocker/SKILL.md
@@ -9,23 +9,17 @@ You are an AI agent acting as a development lead responsible for recording exter
 
 The backlog lives in GitHub: items are GitHub Issues, prioritization happens inside a linked GitHub Project (v2), and version planning happens through GitHub Milestones.
 
----
-
 ## Objective
 
 Create a lightweight stub issue (`type:external-blocker`) that represents an external constraint — an API limitation, vendor issue, regulatory hold, or any other blocker that cannot be expressed as a standard GitHub issue — and immediately register it as a `blocked_by` dependency on the target backlog item.
 
 `type:external-blocker` stubs are **infrastructure only**: they are added to the Project board with Status=`Todo` so they can be tracked and have their health audited, but never milestoned, never assigned `priority:*` or `effort:*` labels, and skipped by execution and planning skills.
 
----
-
 ## Workflow
 
 ### 0. Preflight (MANDATORY)
 
 Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
-
----
 
 After preflight succeeds, use `TaskCreate` to create one task per workflow step below. Mark each task `in_progress` when you begin it and `completed` when it finishes.
 
@@ -38,8 +32,6 @@ Accept from the user argument or conversation:
 
 If either is missing, STOP and ask the user to supply both. If `#N` is closed, STOP and output: `#N is already closed — external blockers apply only to open items.`
 
----
-
 ### 2. Target Issue Validation (MANDATORY)
 
 Confirm `#N` is accessible and open:
@@ -51,8 +43,6 @@ gh issue view <N> --json number,title,state,url
 If not found or closed, STOP and surface the error or state verbatim.
 
 Warn if `#N` already carries `type:external-blocker` — it is unusual to block a stub with another stub. Ask for confirmation before proceeding.
-
----
 
 ### 3. Stub Creation (STRICT)
 
@@ -109,8 +99,6 @@ gh project item-edit \
 
 Use the `project_id`, `project_number`, and `status_field_id` / `status_options.Todo` values already loaded from `.claude/backlog-project.json`.
 
----
-
 ### 4. Dependency Registration (STRICT)
 
 Delegate to `/block-item` to register the stub as a blocker of `#N`:
@@ -119,10 +107,7 @@ Delegate to `/block-item` to register the stub as a blocker of `#N`:
 /block-item #<N> #<stub>
 ```
 
-
 If it reports `Issue Dependencies API unavailable on this repo — blocked_by not applied`, append: `Stub #<stub> was created but is not linked as a blocker.` and STOP.
-
----
 
 ## Rules & Constraints
 
@@ -133,8 +118,6 @@ If it reports `Issue Dependencies API unavailable on this repo — blocked_by no
 - If the user wants to block an item with an existing stub (already created), direct them to `/block-item #N #stub` instead of creating a duplicate
 - Stubs are resolved (closed) via `/resolve-external-blocker` — never close them manually
 - Surface all `gh` errors verbatim — never swallow
-
----
 
 ## Output Expectations
 

--- a/skills/add-item/SKILL.md
+++ b/skills/add-item/SKILL.md
@@ -9,15 +9,11 @@ You are an AI agent acting as a Senior Project Manager responsible for maintaini
 
 Your goal is to define, refine, prioritize, and add high-quality backlog items to GitHub using strict product and engineering standards.
 
----
-
 ## Workflow
 
 ### 0. Preflight (MANDATORY)
 
 Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
-
----
 
 After preflight succeeds, use `TaskCreate` to create one task per workflow step below. Mark each task `in_progress` when you begin it and `completed` when it finishes.
 
@@ -34,8 +30,6 @@ After preflight succeeds, use `TaskCreate` to create one task per workflow step 
   - **Sub-issue parent**: Is this a sub-task of a parent issue / epic? (issue number, optional — sub-issues stay independent: they do NOT inherit the parent's milestone, priority, or rank)
 - Challenge vague or poorly defined requests
 - DO NOT create a backlog item until all critical ambiguities are resolved
-
----
 
 ### 2. Definition (STRICT)
 
@@ -56,8 +50,6 @@ Type, Priority, and Effort are NOT in the body — they are applied as repositor
 - `priority:<P0|P1|P2|P3>` — exactly one priority label
 - `effort:<XS|S|M|L|XL>` — exactly one effort label, based on complexity (NOT time)
 
----
-
 ### 3. INVEST Enforcement (MANDATORY)
 
 Delegate to the `invest-gate` agent with the body constructed in step 2 and the issue title.
@@ -68,8 +60,6 @@ If `invest-gate` returns `Overall: FAIL`:
 - Show the per-letter verdict to the user
 - For any `FAIL` letter, propose a corrected version of the relevant section
 - Do NOT proceed to step 4 until the user approves corrections and `invest-gate` returns `Overall: PASS`
-
----
 
 ### 4. Classification + Label Application
 
@@ -88,8 +78,6 @@ Handle the returned verdict:
 
 These labels will be passed as `labels` in the manifest in step 9.
 
----
-
 ### 5. Validation
 
 Ensure:
@@ -102,15 +90,11 @@ Ensure:
 If too large → propose splitting
 If too vague → request clarification
 
----
-
 ### 6. Dependencies & Sub-issue Linkage
 
 Include in the manifest any relationships gathered in step 1 (Discovery) — `blocked_by`, `blocking`, and `parent`.
 
 If the user did not name any blockers, blocking items, or a sub-issue parent, omit these fields entirely.
-
----
 
 ### 7. Execution Rank (MANDATORY, RELATIVE)
 
@@ -145,8 +129,6 @@ After the user confirms the proposed Rank placements, include the confirmed `ran
 
 If the user prefers to apply moves manually, omit `rank` and `rank_adjustments` from the manifest and instruct the user to drag-drop in the Project's web UI.
 
----
-
 ### 8. Milestone Assignment (OPTIONAL, RECOMMENDED)
 
 Run `resolve-milestone` via the Bash tool. If it exits non-zero, STOP and surface its output verbatim. On success, capture the JSON — `{"number": N, "title": "...", "due_on": "..."}`. If no Active Release exists, the script has already stopped with an error.
@@ -155,8 +137,6 @@ Ask the user whether to assign this item to the Active Release:
 
 - If yes: include `"milestone": "<milestone-title>"` in the manifest passed to `create-item`
 - If no: omit the `milestone` field (will be picked up by `execute-item` only after items in the Active Release are exhausted)
-
----
 
 ### 9. Issue Creation & Project Setup (MANDATORY)
 
@@ -172,8 +152,6 @@ See [issue-manifest.md](./issue-manifest.md) for the full manifest schema.
 
 If `create-item` exits non-zero, STOP and surface its stderr output verbatim.
 
----
-
 ### 10. Output
 
 Using the JSON blob returned by `create-item`, print:
@@ -187,8 +165,6 @@ Using the JSON blob returned by `create-item`, print:
 - Blocking (`.blocking` list) — or "none"
 - Sub-issue parent (`.parent`) — or "none"
 - Any warnings (`.warnings` — surface each one verbatim)
-
----
 
 ## Rules & Constraints
 

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -11,13 +11,9 @@ The backlog lives in GitHub: items are GitHub Issues, prioritization happens ins
 
 Your role is to run a read-only audit by delegating to the `backlog-auditor` agent and displaying the returned report. This skill is **read-only** — it never mutates issues, labels, projects, or milestones.
 
----
-
 ## Objective
 
 Audit the backlog to confirm it meets all defined quality, consistency, and integrity standards before it is used for execution.
-
----
 
 ## Workflow
 
@@ -25,26 +21,18 @@ Audit the backlog to confirm it meets all defined quality, consistency, and inte
 
 Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
 
----
-
 ### 1. Delegate Audit (MANDATORY)
 
 Spawn the `backlog-auditor` agent, passing: `project_number`, `owner` and `repo`.
-
----
 
 ### 2. Display Report (MANDATORY)
 
 Display the Validation Report returned by `backlog-auditor` verbatim.
 
----
-
 ## Rules & Constraints
 
 - Do NOT modify any issue, label, project, or milestone
 - All `gh` errors surfaced verbatim
-
----
 
 ## Success Criteria
 

--- a/skills/block-item/SKILL.md
+++ b/skills/block-item/SKILL.md
@@ -9,21 +9,15 @@ You are an AI agent acting as a development lead responsible for managing issue 
 
 The backlog lives in GitHub: items are GitHub Issues, prioritization happens inside a linked GitHub Project (v2), and version planning happens through GitHub Milestones.
 
----
-
 ## Objective
 
 Register a `blocked_by` dependency between two GitHub issues: mark issue `#N` as blocked by issue `#M`. Works for any two GitHub issues — not limited to items in the linked Project or the active Milestone.
-
----
 
 ## Workflow
 
 ### 0. Preflight (MANDATORY)
 
 Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
-
----
 
 After preflight succeeds, use `TaskCreate` to create one task per workflow step below. Mark each task `in_progress` when you begin it and `completed` when it finishes.
 
@@ -35,8 +29,6 @@ Accept two issue references from the user argument or conversation:
 - `#M` — the issue that is blocking it (the blocker)
 
 Both may be in the same repo or in different repos. If a cross-repo reference is provided, expect a full URL or `<owner>/<repo>#<number>` format. If either reference is missing or ambiguous, STOP and ask the user to supply both.
-
----
 
 ### 2. Issue Validation (MANDATORY)
 
@@ -53,8 +45,6 @@ Surface to the user:
 - Both issue titles and states (open/closed)
 - A warning if `#M` is already closed (the dependency is technically valid but may be stale)
 
----
-
 ### 3. ID Resolution (MANDATORY)
 
 The GitHub Dependencies API requires the numeric database `id`, not the human-visible `number`:
@@ -65,8 +55,6 @@ The GitHub Dependencies API requires the numeric database `id`, not the human-vi
   - Cross-repo: `gh api "repos/<blocker-owner>/<blocker-repo>/issues/<M>" --jq '.id'`
 
 Capture both IDs for use in step 4.
-
----
 
 ### 4. Dependency Creation (STRICT)
 
@@ -85,8 +73,6 @@ If the API returns any other error, surface it verbatim and STOP.
 
 Cross-repo blockers are permitted — GitHub accepts blockers from other repos. `audit` will flag them as a smell for visibility, but they are not rejected here.
 
----
-
 ### 5. Verification (MANDATORY)
 
 Read back the dependency to confirm it was applied:
@@ -98,8 +84,6 @@ gh api "repos/<owner>/<repo>/issues/<N>/dependencies/blocked_by" \
 
 Confirm `<M>` appears in the response.
 
----
-
 ## Rules & Constraints
 
 - NEVER create the dependency in reverse (`#N` blocking `#M`) unless the user explicitly requests it — run `/block-item #M #N` for the reverse direction
@@ -108,8 +92,6 @@ Confirm `<M>` appears in the response.
 - Cross-Project / cross-repo blockers are permitted and will be flagged (not rejected) by `audit`
 - A closed blocker is technically valid — surface a warning but allow it (stale deps are cleaned up by `audit`)
 - Surface all `gh` errors verbatim — never swallow
-
----
 
 ## Output Expectations
 

--- a/skills/close-release/SKILL.md
+++ b/skills/close-release/SKILL.md
@@ -9,21 +9,15 @@ You are an AI agent acting as a release manager responsible for orchestrating a 
 
 The backlog lives in GitHub: items are GitHub Issues, prioritization happens inside a linked GitHub Project (v2), and version planning happens through GitHub Milestones.
 
----
-
 ## Objective
 
 Close a GitHub Milestone cleanly: resolve every open issue interactively, satisfy all project-specific pre-closure requirements (version bumps, release instructions from project docs), compose and create a GitHub Release draft, and close the Milestone — in that order.
-
----
 
 ## Workflow
 
 ### 0. Preflight (MANDATORY)
 
 Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
-
----
 
 After preflight succeeds, use `TaskCreate` to create one task per workflow step below. Mark each task `in_progress` when you begin it and `completed` when it finishes.
 
@@ -34,8 +28,6 @@ The skill accepts an optional milestone argument (title substring or version str
 Run `resolve-milestone "<argument>"` if an argument was provided, or `resolve-milestone` (no argument) for the Active Release. If it exits non-zero, STOP and surface its output verbatim.
 
 Display the resolved milestone title, number, `due_on`, and open/closed issue counts. Use **AskUserQuestion** to ask for explicit confirmation before proceeding — **closing a milestone is irreversible**.
-
----
 
 ### 2. Open Issue Resolution (STRICT)
 
@@ -64,8 +56,6 @@ After all open issues are resolved, print a disposition summary before proceedin
 - Carried forward: #N list → next milestone title
 - Closed as won't fix: #N list
 - Returned to backlog: #N list
-
----
 
 ### 3. Pre-closure Checklist (MANDATORY)
 
@@ -114,8 +104,6 @@ Assemble the full release notes in this order:
 
 Present the composed draft to the user for review and use **AskUserQuestion** to ask for explicit approval or requested edits before proceeding. Do NOT create the GitHub Release until the notes are approved.
 
----
-
 ### 5. GitHub Release Creation (MANDATORY)
 
 Create the GitHub Release in **draft** state with the approved notes:
@@ -139,8 +127,6 @@ git push origin "<milestone-title>"
 
 If the tag push fails (e.g. the tag already exists locally or on the remote), surface the error verbatim and use **AskUserQuestion** to prompt the user to resolve it before continuing. Do NOT proceed to Step 6 until the tag push succeeds.
 
----
-
 ### 6. Milestone Closure (MANDATORY)
 
 Close the milestone only after Steps 2–5 are fully complete:
@@ -148,8 +134,6 @@ Close the milestone only after Steps 2–5 are fully complete:
 `gh api -X PATCH "repos/<owner>/<repo>/milestones/<milestone-number>" -f state=closed`
 
 Surface any error verbatim. Do not proceed to Step 7 if this call fails.
-
----
 
 ### 7. Output Summary
 
@@ -168,8 +152,6 @@ Print:
   - "Run `/plan-release` to open the next milestone"
   - "Publish the Release draft on GitHub when ready: <release-url>"
 
----
-
 ## Rules & Constraints
 
 - Do NOT close the milestone until all open issues are resolved (Step 2), the pre-closure checklist is satisfied (Step 3), the release notes are approved (Step 4), and the Release draft is created (Step 5).
@@ -182,8 +164,6 @@ Print:
 - All `gh` errors must be surfaced verbatim — never swallow.
 - Milestone closure is irreversible — always use **AskUserQuestion** to confirm the resolved milestone with the user before any destructive action.
 - Always use the milestone **title** (not number) when reassigning issues with `gh issue edit --milestone`.
-
----
 
 ## Output Expectations
 

--- a/skills/execute-item/SKILL.md
+++ b/skills/execute-item/SKILL.md
@@ -7,15 +7,11 @@ description: Pick and execute the topmost unblocked Workable Item from the Queue
 
 You are an AI agent acting as a development lead. Select and execute the topmost actionable Workable Item, scoped to the Active Release first, then to un-milestoned items as a fallback.
 
----
-
 ## Workflow
 
 ### 0. Preflight (MANDATORY)
 
 Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
-
----
 
 After preflight succeeds, use `TaskCreate` to create one task per workflow step below. Mark each task `in_progress` when you begin it and `completed` when it finishes.
 
@@ -74,8 +70,6 @@ If `candidate.comments` is non-empty, display the full comment thread before pro
 
 One block per comment, in chronological order. Skip this section entirely when `candidate.comments` is empty.
 
----
-
 ### 3. Sub-issue Scope Check
 
 Use `candidate.sub_issues_summary` from the script output — no API call needed.
@@ -88,8 +82,6 @@ Note: Open sub-issue routing is already handled by `pick-item` — if the script
 #### type:epic Gate
 
 If `candidate.labels` includes `type:epic` AND the item did not enter Scope Completeness Review above: STOP and tell the user to decompose the epic into sub-issues or add them into the project.
-
----
 
 ### 4. Item Validation (MANDATORY)
 
@@ -111,8 +103,6 @@ If any principle fails:
 - Ask: "Would you like to refine this item now? Run `/refine-item <n>` to walk through a guided refinement session, then re-run `/execute-item` when it is ready."
 
 If priority or effort labels are missing or duplicated, STOP and direct the user to run `/audit`.
-
----
 
 ### 5. Planning
 
@@ -174,8 +164,6 @@ If two or more sub-issues were just created:
 
 - Wait for explicit approval before proceeding
 
----
-
 ### 6. Status → In Progress (BEFORE BRANCH)
 
 Once the plan is approved:
@@ -185,8 +173,6 @@ Once the plan is approved:
    - Resolve field/option IDs: `gh project field-list <project-number> --owner <owner> --format json`
    - Find the item ID via `gh project item-list <project-number> --owner <owner> --format json --query "#<n>"`
    - Update: `gh project item-edit --id <item-id> --project-id <project-id> --field-id <status-field-id> --single-select-option-id <in-progress-option-id>`
-
----
 
 ### 7. Branching
 
@@ -202,8 +188,6 @@ Determine the Conventional Commits prefix from the issue's `type:*` label:
 - Any other custom `type:*` label → use the label value as the prefix (e.g. `type:data-pipeline` → `data-pipeline/`); if the value contains `:`, strip it
 
 Branch name format: `<prefix>/<slug>` (e.g. `fix/null-pointer-in-authn`).
-
----
 
 ### 8. Implementation
 
@@ -223,15 +207,11 @@ When the item carries `type:spike`: read [spike-lifecycle.md](./spike-lifecycle.
 - Implement what was described following the existing project patterns
 - Add new tests that validate Acceptance Criteria
 
----
-
 ### 9. Validation
 
 - Verify ALL Acceptance Criteria are satisfied
 - Run full test suite
 - Ensure no regressions
-
----
 
 ### 10. Delivery Workflow
 
@@ -240,8 +220,6 @@ When the item carries `type:spike`: read [spike-lifecycle.md](./spike-lifecycle.
 - Open a Pull Request via `gh pr create`, passing `--milestone "<milestone-title>"` when the issue has one (omit for un-milestoned items). PR body MUST include:
   - `Closes #<issue-number>` (so GitHub auto-links and auto-closes the issue on merge)
   - A summary of changes mapped to each Acceptance Criterion
-
----
 
 ### 11. Status & Closure (POST-PR)
 
@@ -254,8 +232,6 @@ GitHub handles the rest automatically:
 If the Project's `Issue closed → Status: Done` workflow is disabled, manually update Status:
 
 - `gh project item-edit --id <item-id> --project-id <project-id> --field-id <status-field-id> --single-select-option-id <done-option-id>`
-
----
 
 ### 12. Output
 
@@ -270,8 +246,6 @@ Print:
 - Items skipped above this one because they were blocked (with `#N` and the open blockers that gated them; `type:external-blocker` blockers shown as `External: <stub title>`) — surfaces why the picked item wasn't necessarily the topmost
 - Parent items skipped because open sub-issues were found in the Project's Todo column (log: `Skipping parent #N — open sub-issues found. Picking #M.`)
 - Whether this item was **resumed** (was already In Progress) or **newly picked** (was Todo)
-
----
 
 ## Rules & Constraints
 

--- a/skills/health/SKILL.md
+++ b/skills/health/SKILL.md
@@ -11,21 +11,15 @@ The backlog lives in GitHub: items are GitHub Issues, prioritization happens ins
 
 This skill is **read-only** — it never mutates issues, labels, projects, or milestones.
 
----
-
 ## Objective
 
 Produce a Markdown strategic portfolio health report covering: open-issue distribution by type, priority, and effort; age cohorts; overdue high-priority items; stale In-Progress items; and metadata debt (items missing label coverage). The report is suitable for weekly leadership updates, retrospectives, or health checks.
-
----
 
 ## Workflow
 
 ### 0. Preflight (MANDATORY)
 
 Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
-
----
 
 After preflight succeeds, use `TaskCreate` to create one task per workflow step below. Mark each task `in_progress` when you begin it and `completed` when it finishes.
 
@@ -42,8 +36,6 @@ Run these two queries:
    `gh project item-list <project-number> --owner <owner> --format json --limit 200 --query "is:issue"`
 
    Build a lookup map: issue `number` → Project `Status` (`Todo` / `In Progress` / `Done`). Issues absent from the map are classified as "Not in Project."
-
----
 
 ### 2. Compute Report Sections (MANDATORY)
 
@@ -93,8 +85,6 @@ If none exist, emit `✅ No stale In-Progress items.`
 Issues missing any of `type:*`, `priority:*`, or `effort:*` labels. For each such issue, note which label group(s) are absent.
 
 If all issues have complete metadata, emit `✅ All open items have complete label metadata.`
-
----
 
 ### 3. Report Assembly (MANDATORY)
 
@@ -186,8 +176,6 @@ Emit `✅ No stale In-Progress items.` when empty.
 
 Emit `✅ All open items have complete label metadata.` when empty.
 
----
-
 ## Rules & Constraints
 
 - This skill is **strictly read-only** — never mutate any issue, Project field, milestone, or label.
@@ -198,8 +186,6 @@ Emit `✅ All open items have complete label metadata.` when empty.
 - "Age" is computed from `createdAt` (UTC); "last activity" from `updatedAt` (UTC).
 - If the Project item-list call fails, emit the error verbatim and omit the Status-dependent sections (Stale In-Progress); continue with all other sections using available data.
 - Do NOT recommend execution order or triage actions — this skill surfaces state only.
-
----
 
 ## Output Expectations
 

--- a/skills/initialize/SKILL.md
+++ b/skills/initialize/SKILL.md
@@ -11,8 +11,6 @@ Your goal is to provision the GitHub primitives the other backlog skills depend 
 
 This skill is **idempotent**: re-running it on a repo where the project already exists must not duplicate or destroy anything.
 
----
-
 ## Objective
 
 Make the repository ready to host backlog items as GitHub Issues, prioritized inside a linked GitHub Project (v2), so that:
@@ -20,8 +18,6 @@ Make the repository ready to host backlog items as GitHub Issues, prioritized in
 - All other skills can all read project metadata from `.claude/backlog-project.json`
 - Issues created by any skill share the same body shape (driven by the Issue Forms template)
 - Labels are uniform across `type:*`, `priority:*`, and `effort:*`
-
----
 
 ## Workflow
 
@@ -42,8 +38,6 @@ If any required preflight step fails:
 - Report the missing prerequisite explicitly
 - Do NOT continue to provisioning
 
----
-
 After preflight succeeds, use `TaskCreate` to create one task per workflow step below. Mark each task `in_progress` when you begin it and `completed` when it finishes.
 
 ### 1. Project Detection (IDEMPOTENT)
@@ -57,8 +51,6 @@ Before creating anything:
   - Record its number and URL
   - SKIP step 2
   - Continue with label and template provisioning (which are also idempotent)
-
----
 
 ### 2. Project Creation
 
@@ -85,8 +77,6 @@ If no matching Project exists:
   - `In Progress`
   - `Done`
 - If the user has customized the Status field options, STOP and use AskUserQuestion with options: "Add missing options" / "Rename existing options" / "Cancel" — DO NOT silently overwrite
-
----
 
 ### 3. Label Provisioning (IDEMPOTENT)
 
@@ -128,8 +118,6 @@ Effort label descriptions MUST NOT include time estimates (e.g. "2 hours", "1 da
 - `needs-clarification` — `"Item needs more information before it can be worked"`
 
 Apply distinct color groupings (e.g. priority shades from red→grey, effort shades light→dark, type using semantic colors).
-
----
 
 ### 4. Issue Forms Template (CANONICAL BODY SHAPE — VIA PR)
 
@@ -183,8 +171,6 @@ Schema notes:
 - This file is the single source of truth for project metadata — all other skills read it directly with no fallback
 - Re-running `initialize` on a fully-provisioned repo MUST refresh this file
 
----
-
 ### 6. Output Summary
 
 Print a structured summary so the user can verify provisioning:
@@ -198,8 +184,6 @@ Print a structured summary so the user can verify provisioning:
 - Status field options confirmed
 - Metadata file path: `.claude/backlog-project.json`
 
----
-
 ## Rules & Constraints
 
 - Re-running this skill on a fully-provisioned repo MUST be a no-op except for printing the summary
@@ -208,8 +192,6 @@ Print a structured summary so the user can verify provisioning:
 - Stop and ask before opening a PR that would replace a pre-existing `.github/ISSUE_TEMPLATE/backlog-item.yml`
 - NEVER commit `.github/ISSUE_TEMPLATE/backlog-item.yml` directly to the default branch — always go through a PR
 - All `gh` errors must be surfaced verbatim to the user — do not swallow them
-
----
 
 ## Output Expectations
 

--- a/skills/migrate/SKILL.md
+++ b/skills/migrate/SKILL.md
@@ -11,8 +11,6 @@ Your goal is to convert an existing backlog (typically a `TODO.md` or `BACKLOG.m
 
 The local source backlog is **input only**. After migration, GitHub is canonical and the local file should not be edited going forward.
 
----
-
 ## Objective
 
 Transform ALL existing backlog items into GitHub Issues while:
@@ -23,15 +21,11 @@ Transform ALL existing backlog items into GitHub Issues while:
 - Avoiding fabrication of missing information
 - Producing a validated, production-ready backlog inside the linked Project
 
----
-
 ## Workflow
 
 ### 0. Preflight (MANDATORY)
 
 Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
-
----
 
 After preflight succeeds, use `TaskCreate` to create one task per workflow step below. Mark each task `in_progress` when you begin it and `completed` when it finishes.
 
@@ -45,8 +39,6 @@ If item boundaries are unclear:
 
 - Infer cautiously
 - Flag ambiguity in the Migration Report
-
----
 
 ### 2. Normalization
 
@@ -62,8 +54,6 @@ For EACH item, derive the GitHub-native representation:
   - Source `In Progress` → Project `In Progress`
   - Source `Done` / `Completed` / shipped items → **SKIPPED** (see step 8). Done items are historical and are NOT migrated to GitHub.
 
----
-
 ### 3. Missing Information Handling (CRITICAL)
 
 If data is missing or unclear:
@@ -78,8 +68,6 @@ Additionally:
 - List questions required to complete the item in the Migration Report
 - Highlight risks from missing info
 
----
-
 ### 4. INVEST Evaluation
 
 For each item, delegate to the `invest-gate` agent with the normalized body and title.
@@ -89,8 +77,6 @@ If `invest-gate` returns `Overall: FAIL`:
 - Capture each `FAIL` letter's reasoning in `### INVEST Notes`
 - Suggest improvements in the Migration Report (do NOT silently rewrite intent)
 - Apply the `needs-clarification` label to the item
-
----
 
 ### 5. Label Application
 
@@ -107,15 +93,11 @@ Apply the returned verdicts:
 
 Never assign `type:external-blocker` — stubs are infrastructure and are never migrated from backlog files.
 
----
-
 ### 6. Deduplication & Structuring
 
 - Detect duplicates or overlaps across the source backlog
 - DO NOT auto-merge or auto-split
 - In the Migration Report, list all dedup/split suggestions for user review
-
----
 
 ### 7. VALIDATION STEP (HARD GATE)
 
@@ -133,8 +115,6 @@ If any check fails:
 - STOP
 - Report validation errors
 - Provide corrected version OR request clarification before any GitHub mutations happen
-
----
 
 ### 8. Migration Execution
 
@@ -263,8 +243,6 @@ After all issues are created and dependencies are applied, set the execution ord
    ```
    Use the `id` fields from the `item-list` response. To place an item at the very top, omit `afterId` (or set it to `null`). Apply positions top-to-bottom to avoid ordering conflicts.
 
----
-
 ### 9. Migration Report (MANDATORY)
 
 After all items are processed, output a Migration Report containing:
@@ -284,8 +262,6 @@ After all items are processed, output a Migration Report containing:
   - Rejected: candidates the user declined
   - Unresolved: hints whose target couldn't be matched (manual resolution needed) OR whose target was a skipped Done item
 
----
-
 ## Rules & Constraints
 
 - NEVER fabricate requirements
@@ -298,8 +274,6 @@ After all items are processed, output a Migration Report containing:
 - Do NOT mutate GitHub before the hard validation gate passes
 - Do NOT delete or modify the source backlog file — it is input only
 - Issue body section headings MUST match the Issue Forms template exactly so `audit` can parse them
-
----
 
 ## Output Expectations
 

--- a/skills/plan-release/SKILL.md
+++ b/skills/plan-release/SKILL.md
@@ -12,8 +12,6 @@ Your goal is to inspect the current set of GitHub Releases and Milestones, selec
 
 A GitHub Milestone is the unit of version planning for this skill — backlog items (Issues) are assigned to a milestone to declare which release they belong to.
 
----
-
 ## Objective
 
 Either:
@@ -21,15 +19,11 @@ Either:
 - **Creation mode** (no argument, or argument that doesn't match an open milestone): Create a GitHub Milestone for the next release, with a release mode chosen by the user (Maintenance / Regular / Automated), a scope of backlog items, a coherent version name, a due date, a description, and all scoped items assigned.
 - **Re-planning mode** (argument matches an existing open milestone): Interactively adjust the scope of that milestone — add unassigned backlog items and remove currently assigned items with explicit disposition choices.
 
----
-
 ## Workflow
 
 ### 0. Preflight (MANDATORY)
 
 Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
-
----
 
 After preflight succeeds, use `TaskCreate` to create one task per workflow step below. Mark each task `in_progress` when you begin it and `completed` when it finishes.
 
@@ -43,8 +37,6 @@ Check whether the skill was invoked with an argument (a milestone identifier: ti
   - **Exit non-zero (no match)** — ask: "No open milestone found matching `<argument>`. Would you like to plan a new release instead?"
     - If yes: proceed to Step 2 (creation mode), carrying the argument as a suggested version name for Step 6.
     - If no: STOP.
-
----
 
 ### 2. Existing Releases & Milestones Inventory
 
@@ -67,8 +59,6 @@ If multiple schemes are mixed (e.g. some `v1.x`, some `2026-Qx`):
 - STOP
 - Ask the user to clarify which scheme should be used going forward
 
----
-
 ### 3. Release Mode Selection
 
 Use `AskUserQuestion` to ask the user which release mode to use:
@@ -76,8 +66,6 @@ Use `AskUserQuestion` to ask the user which release mode to use:
 - **Maintenance release**: scope is defined by the user (explicit list of issues). Targets any `major.minor` release — including the latest — when only bug fixes, security patches, or small corrections are intended. Version will be a patch on that release.
 - **Regular release**: fetch all unassigned backlog items and let the user select the scope interactively.
 - **Automated release planning**: fetch all unassigned backlog items, analyze them as an experienced Project Manager (priority, theme, dependencies), and propose a coherent release scope with rationale. User confirms or adjusts.
-
----
 
 ### 4. Scope Definition
 
@@ -128,8 +116,6 @@ Use `AskUserQuestion` to ask the user which release mode to use:
 - Present the suggested scope with rationale (why each item was included, overall release theme, dependency chains pulled in, items excluded due to external blockers).
 - Let the user confirm, remove items, or add items from the remaining pool (adding an externally-blocked item requires explicit user confirmation).
 
----
-
 ### 5. Version Inference
 
 After scope is confirmed, infer the appropriate version. Do NOT propose a version before this step.
@@ -149,8 +135,6 @@ Present the inferred bump type with rationale (e.g. "Minor bump — scope contai
 
 Follow the existing naming pattern (next period, continuation of observed naming) — scope content does not drive version naming for non-semver schemes.
 
----
-
 ### 6. Version Proposal & Confirmation
 
 - Compute the concrete version string from the inferred bump and existing release/milestone history.
@@ -165,8 +149,6 @@ Follow the existing naming pattern (next period, continuation of observed naming
 
 Wait for explicit user confirmation of the version name before proceeding.
 
----
-
 ### 7. Milestone Metadata
 
 Collect from the user (with sensible defaults):
@@ -179,16 +161,12 @@ Collect from the user (with sensible defaults):
   - Note any notable dependency chains or constraints surfaced during scope definition
   - Present the suggested description to the user and ask for confirmation or edits before proceeding. Do NOT create the milestone until the description is approved (or explicitly waived).
 
----
-
 ### 8. Milestone Creation
 
 Create the milestone via the GitHub API:
 
 - `gh api -X POST "repos/<owner>/<repo>/milestones" -f title=<title> -f due_on=<due_on> -f description=<description>`
 - Capture the returned `number` and `html_url`
-
----
 
 ### 9. Issue Assignment
 
@@ -209,8 +187,6 @@ After all issues are assigned, ask:
   - Add the clone to the Project with Status=`Todo` and no milestone assigned.
 - **If no**: skip — the scoped issues remain assigned to the maintenance milestone only.
 
----
-
 ### 10. Output Summary
 
 Print:
@@ -230,6 +206,3 @@ Print:
 - Pointer to next steps:
   - "Run `/add-item` to add more items to this milestone"
   - "Run `/execute-item` to start working on this milestone"
-
----
-

--- a/skills/plan-release/re-planning.md
+++ b/skills/plan-release/re-planning.md
@@ -19,8 +19,6 @@ Todo (N):        #n title [effort]  ...
 
 Items with In Progress or Done status are shown as read-only context throughout the session — they cannot be added to or removed from the milestone via this skill.
 
----
-
 ## Actions
 
 Use `AskUserQuestion` to open the main session menu:
@@ -129,15 +127,11 @@ Apply the disposition:
 
 After processing all selected items, recompute and display the updated capacity estimate.
 
----
-
 ## Session Loop
 
 After completing an Add or Remove flow, re-issue the main `AskUserQuestion` from the Actions step so the user can continue adjusting or exit.
 
 Proceed to the next step ONLY when the user chooses "Done — show summary".
-
----
 
 ## Session Summary
 
@@ -154,13 +148,9 @@ Print:
   - "Run `/add-item` to add more items to this milestone"
   - "Run `/execute-item` to start working on this milestone"
 
----
-
 ## Rules & Constraints
 
 - All `gh` errors must be surfaced verbatim, never silent skip errors
-
----
 
 ## Output Expectations
 

--- a/skills/refine-item/SKILL.md
+++ b/skills/refine-item/SKILL.md
@@ -11,8 +11,6 @@ The backlog lives in GitHub: items are GitHub Issues, prioritization happens ins
 
 Items carrying the `needs-clarification` label were created by `migrate` (or flagged later) because they are missing critical detail — typically with `UNKNOWN` / `NEEDS CLARIFICATION` markers in body sections and open questions parked in `### INVEST Notes`. Your goal is to walk this one item through interactive discovery, fill the gaps, re-evaluate severity / effort / type / Project rank using full relative analysis, and remove the `needs-clarification` label once validation passes.
 
----
-
 ## Objective
 
 Bring the target issue to a fully refined state where:
@@ -24,15 +22,11 @@ Bring the target issue to a fully refined state where:
 - Project rank reflects the refined understanding (re-evaluated relatively)
 - The `needs-clarification` label is removed
 
----
-
 ## Workflow
 
 ### 0. Preflight (MANDATORY)
 
 Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
-
----
 
 After preflight succeeds, use `TaskCreate` to create one task per workflow step below. Mark each task `in_progress` when you begin it and `completed` when it finishes.
 
@@ -44,8 +38,6 @@ After preflight succeeds, use `TaskCreate` to create one task per workflow step 
   - No argument — ask: "Which issue should I refine? You can provide an issue number or a title."
 - Fetch issue data and verify the issue is a member of the linked Project: `gh project item-list <project-number> --owner <owner> --format json --query "#<n>"` — if the issue is NOT in the Project, STOP and output: `Issue #<n> is not in the linked Backlog project. Only Project members can be refined here.`
 - If the issue does NOT carry `needs-clarification`, warn: "Issue #<n> does not carry `needs-clarification`. Proceed anyway? [Y/n]" and stop if the user declines.
-
----
 
 ### 2. Display Item
 
@@ -64,8 +56,6 @@ After preflight succeeds, use `TaskCreate` to create one task per workflow step 
     - `gh api "repos/<owner>/<repo>/issues/<n>/dependencies/blocking"`
   - Sub-issue parent (if any): `#N`, title.
     - `gh issue view <n> --json parent --jq '.parent'`
-
----
 
 ### 3. Discovery Dialogue (MANDATORY)
 
@@ -88,8 +78,6 @@ Reuse the discovery pattern from `add-item`:
 - Challenge vague answers — DO NOT accept hand-waving like "improve performance" or "make it better"
 - If the user genuinely cannot answer a question, capture it as a remaining gap (handled in step 5)
 
----
-
 ### 4. Reconstruct Body
 
 Delegate body authoring to the `issue-body-author` agent:
@@ -101,8 +89,6 @@ Delegate body authoring to the `issue-body-author` agent:
 The agent returns an updated body with all `UNKNOWN` / `NEEDS CLARIFICATION` / `_No response_` markers replaced by the discovered content. Any sections where information is still missing will be marked with `<!-- TODO: ... -->` — those remain as open questions in `### INVEST Notes`.
 
 DO NOT introduce new headings or change ordering — `audit` parses these section headings.
-
----
 
 ### 5. INVEST Gate (MANDATORY)
 
@@ -122,16 +108,12 @@ If splitting is needed (S letter fails):
 - Apply the partial body update reflecting the reduced scope of the original item, OR keep the original as-is if the user prefers to handle the split manually
 - KEEP the `needs-clarification` label until the split is resolved
 
----
-
 ### 6. Apply Body Update
 
 If INVEST passes (or partial — per step 5):
 
 - Write the refined body to a temp file (avoids shell-escaping issues)
 - `gh issue edit <n> --body-file <tmp>`
-
----
 
 ### 7. Re-evaluate Labels (RELATIVE)
 
@@ -156,8 +138,6 @@ Apply changes ONLY after explicit user confirmation:
 - `gh issue edit <n> --remove-label <old> --add-label <new>`
 
 If existing items appear misranked in their priority labels relative to the refined item, surface the discrepancy and recommend label changes for those existing items. Apply ONLY after confirmation.
-
----
 
 ### 8. Re-evaluate Project Rank + Dependencies (RELATIVE)
 
@@ -204,8 +184,6 @@ If the Dependencies API is unavailable on this repo (returns `404`), skip blocke
 
 Apply ONLY after explicit user confirmation. Cross-Project / cross-repo blockers ARE permitted but should be flagged in the per-item confirmation so the user knows they exist.
 
----
-
 ### 9. Pre-removal Validation Gate (MANDATORY)
 
 Before removing the `needs-clarification` label, re-fetch the current live state of the issue and validate it:
@@ -231,8 +209,6 @@ If ANY check fails:
 
 If all checks pass, proceed to step 10.
 
----
-
 ### 10. Remove Clarification Label
 
 Only after the pre-removal validation gate passes:
@@ -245,8 +221,6 @@ Only after the pre-removal validation gate passes:
   - Rank change applied (e.g., "moved from Rank 8 to Rank 3")
   - Dependency changes applied (blockers added / removed, sub-issue parent change)
 
----
-
 ## Rules & Constraints
 
 - Do NOT remove `needs-clarification` until the pre-removal validation gate passes (step 9)
@@ -257,8 +231,6 @@ Only after the pre-removal validation gate passes:
 - Effort must NEVER be expressed in time (no hours/days)
 - All `gh` errors surfaced verbatim
 - This skill operates on exactly one issue. Use `/refine` to drive a multi-item session.
-
----
 
 ## Output Expectations
 

--- a/skills/refine/SKILL.md
+++ b/skills/refine/SKILL.md
@@ -9,21 +9,15 @@ You are an AI agent acting as a Senior Project Manager orchestrating a backlog r
 
 The backlog lives in GitHub: items are GitHub Issues, prioritization happens inside a linked GitHub Project (v2), and version planning happens through GitHub Milestones.
 
----
-
 ## Objective
 
 Walk every selected item from two candidate pools — `needs-clarification` issues and issues with incomplete metadata (missing `priority:*` or `effort:*` labels) — through interactive refinement, one at a time, by invoking `/refine-item` for each. At the end, produce a structured report of what was refined, partially refined, or skipped, broken down by source pool.
-
----
 
 ## Workflow
 
 ### 0. Preflight (MANDATORY)
 
 Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
-
----
 
 After preflight succeeds, use `TaskCreate` to create one task per workflow step below. Mark each task `in_progress` when you begin it and `completed` when it finishes.
 
@@ -54,8 +48,6 @@ If both pools are empty:
 - Print `No items need clarification or have incomplete metadata. Done.`
 - STOP
 
----
-
 ### 2. Sort & Display Queue
 
 Build the refinement queue:
@@ -84,8 +76,6 @@ Display the queue as a numbered table with two clearly labeled sections. Numberi
 
 Omit a section header entirely if its pool is empty.
 
----
-
 ### 3. Candidate Selection
 
 After displaying the queue, select items to refine:
@@ -99,8 +89,6 @@ After displaying the queue, select items to refine:
 
 Build the ordered work list from the user's answer, preserving queue order.
 
----
-
 ### 4. Refinement Loop
 
 For each selected item in work-list order:
@@ -111,8 +99,6 @@ For each selected item in work-list order:
 4. If the user selects "Stop", break the loop and jump to step 5.
 
 The loop is safe to interrupt at any point — re-running `/refine` will rebuild the queue from scratch, and already-refined items (label removed) will drop out automatically.
-
----
 
 ### 5. Refinement Report (MANDATORY)
 
@@ -145,16 +131,12 @@ If the loop ended before the full queue was processed, add:
 
 > Re-run `/refine` to continue — already-refined items drop out of the queue automatically.
 
----
-
 ## Rules & Constraints
 
 - Do NOT perform any issue mutations directly — delegate all per-item work to `/refine-item`
 - Do NOT operate on issues outside the linked Project, even if they carry `needs-clarification`
 - The loop is safe to interrupt and resume — the sort is deterministic and idempotent on already-refined items
 - All `gh` errors surfaced verbatim
-
----
 
 ## Output Expectations
 

--- a/skills/release-status/SKILL.md
+++ b/skills/release-status/SKILL.md
@@ -11,21 +11,15 @@ The backlog lives in GitHub: items are GitHub Issues, prioritization happens ins
 
 This skill is **read-only** — it never mutates issues, labels, projects, or milestones.
 
----
-
 ## Objective
 
 Produce a Markdown release health dashboard for a target milestone: issue counts by Project Status, percentage complete, blocked items, and unestimated items — aggregated with zero manual querying with zero manual querying.
-
----
 
 ## Workflow
 
 ### 0. Preflight (MANDATORY)
 
 Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
-
----
 
 After preflight succeeds, use `TaskCreate` to create one task per workflow step below. Mark each task `in_progress` when you begin it and `completed` when it finishes.
 
@@ -34,8 +28,6 @@ After preflight succeeds, use `TaskCreate` to create one task per workflow step 
 The skill accepts an optional milestone argument (title substring or version string).
 
 Run `resolve-milestone "<argument>"` if an argument was provided, or `resolve-milestone` (no argument) for the Active Release. If it exits non-zero, STOP and surface its output verbatim.
-
----
 
 ### 2. Data Collection (MANDATORY)
 
@@ -56,8 +48,6 @@ With the resolved milestone in hand, run these queries:
 
 3. **Unestimated check**:
    For each issue, scan its labels for any `effort:*` label. Issues with none are unestimated.
-
----
 
 ### 3. Report Assembly (MANDATORY)
 
@@ -119,8 +109,6 @@ Issues grouped by Status:
 **📋 Todo (N)**
 - [ ] [#N](\<url\>) — title
 
----
-
 ## Rules & Constraints
 
 - This skill is **strictly read-only** — never mutate any issue, Project field, milestone, or label.
@@ -128,8 +116,6 @@ Issues grouped by Status:
 - Issue Dependencies API `404` must emit one warning line and gracefully skip the blocked-items section; it must not abort the rest of the report.
 - % complete is computed over all non-stub issues returned by the project queries.
 - Do NOT pick or recommend execution order — this skill surfaces state only.
-
----
 
 ## Output Expectations
 

--- a/skills/resolve-external-blocker/SKILL.md
+++ b/skills/resolve-external-blocker/SKILL.md
@@ -9,21 +9,15 @@ You are an AI agent acting as a development lead responsible for resolving exter
 
 The backlog lives in GitHub: items are GitHub Issues, prioritization happens inside a linked GitHub Project (v2), and version planning happens through GitHub Milestones.
 
----
-
 ## Objective
 
 Close an external-blocker stub issue (created by `/add-external-blocker`) with a resolution comment, and surface which backlog items are now unblocked as a result.
-
----
 
 ## Workflow
 
 ### 0. Preflight (MANDATORY)
 
 Read [../github-backlog-management/preflight-contract.md](../github-backlog-management/preflight-contract.md) for the preflight instruction; follow it exactly.
-
----
 
 After preflight succeeds, use `TaskCreate` to create one task per workflow step below. Mark each task `in_progress` when you begin it and `completed` when it finishes.
 
@@ -35,8 +29,6 @@ Accept from the user argument or conversation:
 - `"resolution"` — a short description of how the external constraint was resolved (free text)
 
 If either is missing, STOP and ask the user to supply both.
-
----
 
 ### 2. Stub Validation (STRICT)
 
@@ -55,8 +47,6 @@ Validate:
 
 This guard prevents accidentally closing a real backlog item via this skill.
 
----
-
 ### 3. Identify Blocked Items (MANDATORY)
 
 Before closing the stub, record which open issues are currently blocked by it:
@@ -71,8 +61,6 @@ If the API returns `404`:
 - Proceed to step 4 (close the stub) but skip step 5.
 
 Capture the list of issues returned. Filter to those with `state == "open"` — these are the items potentially unblocked by closing this stub.
-
----
 
 ### 4. Resolution Comment, Closure & Project Status (STRICT)
 
@@ -97,8 +85,6 @@ gh project item-edit \
 
 Resolve `<item-id>` via `gh project item-list <project-number> --owner <owner> --format json --query "#<stub>"` if not already known. Use `project_id`, `project_number`, `status_field_id`, and `status_options.Done` from `.claude/backlog-project.json`. If the Project Status update fails (e.g. the stub was never added to the Project), surface the error as a warning but do not abort — the stub is already closed.
 
----
-
 ### 5. Newly Unblocked Detection (MANDATORY)
 
 For each open issue identified in step 3, re-fetch its remaining blockers to determine if it is now fully unblocked:
@@ -111,8 +97,6 @@ gh api "repos/<owner>/<repo>/issues/<N>/dependencies/blocked_by" \
 - Count = 0 → `#N` is **now unblocked** (all remaining blockers are closed)
 - Count > 0 → `#N` is still blocked (other open blockers remain); list the remaining open blockers by number
 
----
-
 ## Rules & Constraints
 
 - NEVER close a stub that lacks the `type:external-blocker` label — use the guard in step 2 strictly
@@ -120,8 +104,6 @@ gh api "repos/<owner>/<repo>/issues/<N>/dependencies/blocked_by" \
 - Do NOT reopen a closed stub — if the external constraint resurfaces, create a new stub via `/add-external-blocker`
 - If the Dependencies API is unavailable, close the stub anyway — the label guard still protects against mis-closes; the unblocked-detection step is skipped gracefully
 - Surface all `gh` errors verbatim — never swallow
-
----
 
 ## Output Expectations
 

--- a/skills/setup-permissions/SKILL.md
+++ b/skills/setup-permissions/SKILL.md
@@ -7,13 +7,9 @@ description: Write the Claude Code permissions allowlist for this skill into the
 
 You are an AI agent acting as an installation assistant responsible for configuring Claude Code permission settings for the GitHub Backlog Management skill.
 
----
-
 ## Objective
 
 Write the correct `permissions.allow` block into the user's chosen Claude Code settings file, based on their configured or requested permission mode. This skill is idempotent — re-running with the same mode and target is a safe no-op.
-
----
 
 ## Allowlist reference
 
@@ -42,16 +38,12 @@ These are the canonical allowlist blocks for each mode:
 ]
 ```
 
----
-
 ## Workflow
 
 ### 0. Preflight (MANDATORY)
 
 - `gh auth status` — if unauthenticated, STOP and output: `gh auth status failed. Run gh auth login and retry.`
 - Parse `<owner>/<repo>` from `gh repo view --json owner,name`
-
----
 
 After preflight succeeds, use `TaskCreate` to create one task per workflow step below. Mark each task `in_progress` when you begin it and `completed` when it finishes.
 
@@ -65,16 +57,12 @@ Determine the effective permission mode using this precedence:
 
 Valid values: `yolo`, `safe`, `off`. If the resolved value is anything else, STOP and output: `Unknown permission mode "<value>". Valid values: yolo, safe, off.`
 
----
-
 ### 2. Off / Unset path (STRICT)
 
 If the resolved mode is `off`:
 
 - Print exactly: `Permission mode is "off" — no settings written. See README "Authentication & Permissions" for manual configuration.`
 - STOP. Do not read, write, or touch any settings file.
-
----
 
 ### 3. Target file selection (MANDATORY)
 
@@ -86,8 +74,6 @@ Ask the user which file to write. Present exactly three options:
 
 Wait for the user to select one before proceeding.
 
----
-
 ### 4. Idempotent merge and write (STRICT)
 
 1. **Read** the chosen target file. If it does not exist, treat its content as `{}`.
@@ -98,13 +84,9 @@ Wait for the user to select one before proceeding.
 6. If no new rules were added (all already present): print `No changes — all rules already present in <target>.` and STOP.
 7. Write the updated JSON back to the target file with 2-space indentation.
 
----
-
 ### 5. Verification (MANDATORY)
 
 Re-read the target file and confirm all expected rules are present. Output the result summary (see Output Expectations).
-
----
 
 ## Rules & Constraints
 
@@ -114,8 +96,6 @@ Re-read the target file and confirm all expected rules are present. Output the r
 - An explicit argument overrides `userConfig` for this invocation ONLY — do NOT persist or modify the stored `userConfig` value
 - Surface all `gh` errors and file I/O errors verbatim — never swallow
 - If the target file path contains `~`, expand it to the user's home directory using `$HOME`
-
----
 
 ## Output Expectations
 


### PR DESCRIPTION
## Summary

- Removed redundant `---` horizontal-rule dividers between workflow steps and sections across all 22 skill and agent files (these are decorative — numbered step headers already provide separation)
- Converted 4 non-load-bearing two-column tables to compact list form in agent files (`label-classifier`, `dependency-inferrer`, `invest-gate`, `rank-recommender`)
- All genuinely tabular tables (report format templates, lookup tables with meaningful column relationships) were left unchanged

## Acceptance Criteria coverage

- [x] Every touched file is measurably smaller in bytes and/or lines — total: **−392 lines / −1,346 bytes** across 22 files; confirmed via `wc`
- [x] Every genuinely tabular table preserved as a table; only labeled-list tables converted — confirmed by diff review
- [x] No semantic structure removed (headers, numbered steps) and no workflow step, rule, `gh` command, or contract string altered — confirmed by diff review

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)