### PR TITLE
fix(create-item): resolve new item's node ID without a status filter

### DIFF
--- a/bin/create-item
+++ b/bin/create-item
@@ -8,6 +8,14 @@ Usage: create-item --input <json-file>
 Creates a GitHub issue from a manifest JSON file and adds it to the backlog project.
 Emits a JSON result blob to stdout on success. Errors go to stderr.
 
+Exit codes:
+  0  Full success — issue created, no warnings.
+  1  Nothing created — gh issue create itself failed.
+  2  Issue was created, but a post-creation step warned (rank retries
+     exhausted, a rank GraphQL mutation failed, or a rank_adjustments[]
+     entry failed). The JSON blob is still emitted on stdout; do not retry
+     the request — the issue already exists.
+
 Manifest schema (title and body_file are required; all others are optional):
   title           string
   body_file       path to issue body file
@@ -110,30 +118,56 @@ issue_url_out=$(gh issue create "${create_args[@]}" 2>&1) || {
 issue_url=$(echo "$issue_url_out" | tail -1)
 issue_num=$(echo "$issue_url" | grep -oE '[0-9]+$')
 
-# ─── 2 & 3. Apply rank + rank_adjustments (non-fatal) ─────────────────────
+# ─── 2 & 3. Apply rank + rank_adjustments (non-fatal to issue creation) ───
+: "${CREATE_ITEM_RETRY_SLEEP:=1}"
+
 todo_items=""
+all_items=""
 n_adjustments=$(echo "$rank_adjustments_json" | jq 'length')
 
+# Used only to resolve pre-existing items (rank.after_issue, the position:
+# bottom last-item lookup, and rank_adjustments[] targets) — these already
+# have Status = Todo, so the filter is safe and unchanged from before.
 fetch_todo_items() {
   todo_items=$(gh project item-list "$proj_num" --owner "$owner" \
     --format json --limit 200 --query "is:issue status:Todo -label:type:external-blocker" 2>/dev/null) || \
     todo_items='{"items": []}'
 }
 
+# Used only to resolve the newly-created item's own node ID. Its Status is
+# assigned asynchronously by GitHub's "item added to project" workflow, so a
+# status:Todo-filtered query can race it and find nothing — this query is
+# intentionally unfiltered and paired with the retry loop below.
+fetch_all_items() {
+  all_items=$(gh project item-list "$proj_num" --owner "$owner" \
+    --format json --limit 200 --query "is:issue" 2>/dev/null) || \
+    all_items='{"items": []}'
+}
+
 resolve_item_id() {
-  local issue_n="$1"
-  echo "$todo_items" | jq -r \
+  local items_json="$1" issue_n="$2"
+  echo "$items_json" | jq -r \
     --argjson n "$issue_n" \
     '.items // [] | .[] | select(.content.number == $n) | .id' 2>/dev/null | head -1
 }
 
 if [[ "$rank_json" != "null" ]]; then
-  fetch_todo_items
+  item_id=""
+  retry_delays=(1 2 3 4)
+  for attempt in 1 2 3 4 5; do
+    fetch_all_items
+    item_id=$(resolve_item_id "$all_items" "$issue_num")
+    [[ -n "${item_id:-}" && "$item_id" != "null" ]] && break
+    if [[ $attempt -lt 5 ]]; then
+      sleep "$(( retry_delays[attempt-1] * CREATE_ITEM_RETRY_SLEEP ))"
+    fi
+  done
 
-  item_id=$(resolve_item_id "$issue_num")
   if [[ -z "${item_id:-}" || "$item_id" == "null" ]]; then
-    echo "Rank: could not find item for #$issue_num in Todo column" >> "$WARNINGS_FILE"
+    echo "Rank: item #$issue_num not found in Project after 5 attempts" >> "$WARNINGS_FILE"
   else
+    fetch_todo_items
+
     rank_pos=$(echo "$rank_json" | jq -r '.position // null')
     rank_after=$(echo "$rank_json" | jq -r '.after_issue // null')
 
@@ -141,7 +175,7 @@ if [[ "$rank_json" != "null" ]]; then
     if [[ "$rank_pos" == "top" ]]; then
       after_input=""
     elif [[ "$rank_after" != "null" ]]; then
-      after_id=$(resolve_item_id "$rank_after")
+      after_id=$(resolve_item_id "$todo_items" "$rank_after")
       [[ -n "${after_id:-}" && "$after_id" != "null" ]] && \
         after_input=", afterId: \"$after_id\""
     elif [[ "$rank_pos" == "bottom" ]]; then
@@ -166,7 +200,7 @@ if [[ "$n_adjustments" -gt 0 ]]; then
     adj_after=$(echo "$adj" | jq -r '.after_issue // null')
     adj_pos=$(echo "$adj" | jq -r '.position // null')
 
-    adj_item_id=$(resolve_item_id "$adj_issue")
+    adj_item_id=$(resolve_item_id "$todo_items" "$adj_issue")
     if [[ -z "${adj_item_id:-}" || "$adj_item_id" == "null" ]]; then
       echo "rank_adjustments[$i]: item #$adj_issue not found in Todo" >> "$WARNINGS_FILE"
       continue
@@ -176,7 +210,7 @@ if [[ "$n_adjustments" -gt 0 ]]; then
     if [[ "$adj_pos" == "top" ]]; then
       after_input=""
     elif [[ "$adj_after" != "null" ]]; then
-      after_id=$(resolve_item_id "$adj_after")
+      after_id=$(resolve_item_id "$todo_items" "$adj_after")
       [[ -n "${after_id:-}" && "$after_id" != "null" ]] && \
         after_input=", afterId: \"$after_id\""
     fi
@@ -215,3 +249,11 @@ jq -n \
     parent:                   (if $parent == "null" then null else ($parent | tonumber) end),
     warnings:                 $warnings
   }'
+
+# ─── 5. Exit code ─────────────────────────────────────────────────────────
+# The issue was always created by this point (gh issue create failures exit
+# 1 earlier and never reach here). A non-empty warnings file means some
+# post-creation step degraded — surface that generically as exit 2 so any
+# future warning-producing step inherits this for free.
+[[ -s "$WARNINGS_FILE" ]] && exit 2
+exit 0

--- a/skills/add-item/SKILL.md
+++ b/skills/add-item/SKILL.md
@@ -170,7 +170,11 @@ See [issue-manifest.md](./issue-manifest.md) for the full manifest schema.
 3. Run: `create-item --input /tmp/add-item-manifest.json`
 4. Capture the JSON blob emitted to stdout — use it for Step 10.
 
-If `create-item` exits non-zero, STOP and surface its stderr output verbatim.
+Branch on the exit code:
+
+- **Exit 0** — success. Proceed to Step 10 as normal.
+- **Exit 2** — the issue **was created**, but a post-creation step warned. Parse the JSON blob from stdout anyway and proceed to Step 10, reporting the issue as created. Do NOT retry or re-run `create-item` for this request, retrying would create a duplicate.
+- **Any other non-zero exit** — nothing was created (e.g. `gh issue create` itself failed). STOP and surface its stderr output verbatim. It is safe to retry once the underlying input is fixed.
 
 ---
 
@@ -183,6 +187,7 @@ Using the JSON blob returned by `create-item`, print:
 - Project Status (`.status`)
 - Milestone assignment (`.milestone` or "unassigned")
 - Rank applied (`.rank.applied`) and any re-ranked items (`.rank_adjustments_applied`)
+  - If `.rank.applied == false`, do NOT fold this into the generic bullet — render a standalone, prominent line instead: `⚠️ Rank NOT applied — item landed at the bottom of Todo, not the requested position. <matching warning text from .warnings>`
 - Blockers (`.blocked_by` list, with cross-Project / cross-repo blockers explicitly flagged) — or "none"
 - Blocking (`.blocking` list) — or "none"
 - Sub-issue parent (`.parent`) — or "none"

--- a/tests/create-item.bats
+++ b/tests/create-item.bats
@@ -8,6 +8,7 @@ setup() {
   MOCK_BIN="$(mktemp -d)"
   export GH_MOCK_DIR="$(mktemp -d)"
   export PATH="$MOCK_BIN:$PATH"
+  export CREATE_ITEM_RETRY_SLEEP=0
 
   cd "$TEST_DIR"
 
@@ -72,6 +73,15 @@ if [[ "$subcmd" == "issue" ]]; then
 elif [[ "$subcmd" == "project" ]]; then
   subcmd2="${1:-}"; shift || true
   if [[ "$subcmd2" == "item-list" ]]; then
+    counter_file="$GH_MOCK_DIR/item_list_empty_responses"
+    if [[ -f "$counter_file" ]]; then
+      remaining=$(cat "$counter_file")
+      if [[ "$remaining" -gt 0 ]]; then
+        echo $((remaining - 1)) > "$counter_file"
+        echo '{"items": []}'
+        exit 0
+      fi
+    fi
     cat "$GH_MOCK_DIR/items_todo.json" 2>/dev/null || echo '{"items": []}'
     exit 0
   fi
@@ -258,10 +268,11 @@ JSON
 }
 
 # ---------------------------------------------------------------------------
-# AC5 — Non-fatal: rank GraphQL mutation fails → warning in blob, exit 0
+# AC5 — Non-fatal (to the issue): rank GraphQL mutation fails → warning in
+# blob, exit 2 (issue was created, but a post-creation step warned)
 # ---------------------------------------------------------------------------
 
-@test "AC5: GraphQL rank mutation failure adds warning but exits 0" {
+@test "AC5: GraphQL rank mutation failure adds warning and exits 2" {
   local manifest="$GH_MOCK_DIR/manifest.json"
   cat > "$manifest" << JSON
 {
@@ -274,10 +285,90 @@ JSON
   touch "$GH_MOCK_DIR/graphql_fail"
 
   run "$CREATE_ITEM" --input "$manifest"
-  [[ "$status" -eq 0 ]]
+  [[ "$status" -eq 2 ]]
+
+  issue_num=$(echo "$output" | jq -r '.issue.number')
+  [[ "$issue_num" == "42" ]]
 
   rank_applied=$(echo "$output" | jq -r '.rank.applied')
   [[ "$rank_applied" == "false" ]]
+
+  warnings_len=$(echo "$output" | jq '.warnings | length')
+  [[ "$warnings_len" -gt 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# #186 — New item's Status is set asynchronously by GitHub's "item added to
+# project" workflow, so resolving its node ID must retry against an
+# unfiltered item list rather than the status:Todo-filtered one.
+# ---------------------------------------------------------------------------
+
+@test "#186a: item resolves after 2 empty list responses, rank.applied=true, exit 0" {
+  local manifest="$GH_MOCK_DIR/manifest.json"
+  cat > "$manifest" << JSON
+{
+  "title": "Ranked issue",
+  "body_file": "$GH_MOCK_DIR/body.txt",
+  "labels": ["type:feature", "priority:P1", "effort:M"],
+  "rank": {"position": "top"}
+}
+JSON
+  echo "2" > "$GH_MOCK_DIR/item_list_empty_responses"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 0 ]]
+
+  rank_applied=$(echo "$output" | jq -r '.rank.applied')
+  [[ "$rank_applied" == "true" ]]
+
+  warnings=$(echo "$output" | jq -c '.warnings')
+  [[ "$warnings" == "[]" ]]
+}
+
+@test "#186b: item never propagates into the Project, retries exhausted, exit 2 with rank.applied=false" {
+  local manifest="$GH_MOCK_DIR/manifest.json"
+  cat > "$manifest" << JSON
+{
+  "title": "Ranked issue",
+  "body_file": "$GH_MOCK_DIR/body.txt",
+  "labels": ["type:feature", "priority:P1", "effort:M"],
+  "rank": {"position": "top"}
+}
+JSON
+  echo "99" > "$GH_MOCK_DIR/item_list_empty_responses"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 2 ]]
+
+  issue_num=$(echo "$output" | jq -r '.issue.number')
+  [[ "$issue_num" == "42" ]]
+
+  rank_applied=$(echo "$output" | jq -r '.rank.applied')
+  [[ "$rank_applied" == "false" ]]
+
+  warnings_len=$(echo "$output" | jq '.warnings | length')
+  [[ "$warnings_len" -gt 0 ]]
+
+  warnings_text=$(echo "$output" | jq -r '.warnings[]')
+  [[ "$warnings_text" == *"not found in Project"* ]]
+}
+
+@test "#186c: a failed rank_adjustments[] entry also yields exit 2 (generalized exit-code contract)" {
+  local manifest="$GH_MOCK_DIR/manifest.json"
+  cat > "$manifest" << JSON
+{
+  "title": "Test issue title",
+  "body_file": "$GH_MOCK_DIR/body.txt",
+  "labels": ["type:feature", "priority:P2", "effort:S"],
+  "rank_adjustments": [{"issue": 99, "position": "top"}]
+}
+JSON
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 2 ]]
+
+  issue_num=$(echo "$output" | jq -r '.issue.number')
+  [[ "$issue_num" == "42" ]]
 
   warnings_len=$(echo "$output" | jq '.warnings | length')
   [[ "$warnings_len" -gt 0 ]]


### PR DESCRIPTION
## Summary

- `gh issue create --project` adds the item to the Project with no Status value set; `Status = Todo` is assigned afterwards by GitHub's built-in "item added to project" workflow, which runs asynchronously. The immediately-following `status:Todo`-filtered lookup used to resolve the new item's node ID for ranking raced that workflow and almost always lost, silently dropping the requested Rank.
- Splits the item-list lookup into `fetch_all_items()` (unfiltered, retried up to 5 times with increasing backoff — 1s/2s/3s/4s) used only to resolve the *newly created* item's node ID, and the unchanged `status:Todo`-filtered `fetch_todo_items()` used only for pre-existing reference lookups (`after_issue`, `position: bottom`, `rank_adjustments[]`).
- Generalizes the exit-code contract so `add-item`'s driving agent can distinguish "nothing was created" from "it was created, something else warned" and stop blind-retrying into a duplicate issue: exit 1 = nothing created, exit 2 = issue created but a post-creation step warned (rank retries exhausted, rank GraphQL mutation failed, or a `rank_adjustments[]` entry failed), exit 0 = full success. The JSON blob is always emitted on exit 2.
- Updates `skills/add-item/SKILL.md` Step 9/10 to branch on the three exit codes and render a rank failure as a prominent callout.

## Acceptance Criteria

- [x] `create-item` with `{"position": "top"}` places the new item at the top of the Todo column and returns `"rank": {"applied": true}` — covered by `AC2b`, `#186a`.
- [x] `create-item` with `{"after_issue": N}` places the new item directly after issue N — `after_issue` resolution against the (unaffected) Todo-filtered list is unchanged; the new item's own ID now resolves correctly via `fetch_all_items()`/retry, so the mutation is issued with a valid `itemId` instead of being skipped.
- [x] `create-item` with `{"position": "bottom"}` places the new item at the bottom — same fix as above; the `last` lookup against `fetch_todo_items()` is unchanged.
- [x] No `Rank: could not find item for #N in Todo column` warning is emitted on a healthy Project — the new-item lookup no longer filters on Status, so it isn't excluded while its Status is still empty; verified by `#186a` (2 empty responses then a hit, zero warnings).
- [x] A failed rank is surfaced to the user rather than silently degrading to bottom-of-column — exit 2 plus the `add-item` Step 9/10 callout ensures `applied: false` is always rendered prominently instead of being reported as a clean success.
- [x] Covered by a BATS test — `tests/create-item.bats`: `#186a` (resolves after 2 empty responses), `#186b` (retries exhausted → exit 2), `#186c` (a failed `rank_adjustments[]` entry also yields exit 2, proving the exit-code mechanism is general), and `AC5` updated to assert exit 2.

Closes #186