### PR TITLE
fix(pick-item): fall back to Tier 2 when repo has zero open milestones

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -114,6 +114,10 @@ case-insensitive title substring, then by stripping a leading `v` from both side
 Resolved at runtime by `resolve-milestone` (no-arg → Active Release; positional arg →
 named Release; `--exclude "<title>"` → Active Release skipping one Milestone by exact title).
 Output: `{"number": N, "title": "...", "due_on": "..."}` — `due_on` is `null` when unset.
+The Active Release is **undefined** when the backlog has zero open Milestones — whether
+none has ever been created, or all have been closed. This is an ordinary state, not an
+error: `/execute-item` continues to operate, scoped to un-milestoned items only, until a
+Milestone is opened.
 _Avoid_: current milestone, current release
 
 **Release artifact**:

--- a/bin/pick-item
+++ b/bin/pick-item
@@ -19,22 +19,37 @@ repo=$(jq -r '.repo' "$metadata_file")
 proj_num=$(jq -r '.project_number' "$metadata_file")
 
 # ─── 1. Active milestone ──────────────────────────────────────────────────────
-milestone_json=$(resolve-milestone 2>&1) || { echo "$milestone_json" >&2; exit 1; }
-ms_num=$(echo "$milestone_json" | jq -r '.number')
-ms_title=$(echo "$milestone_json" | jq -r '.title')
-ms_due=$(echo "$milestone_json" | jq -r '.due_on')
-active_milestone_out=$(jq -n --argjson n "$ms_num" --arg t "$ms_title" --arg d "$ms_due" \
-  '{number: $n, title: $t, due_on: $d}')
+milestone_json=$(resolve-milestone 2>&1)
+resolve_status=$?
+
+if [[ "$resolve_status" -eq 2 ]]; then
+  # No open milestones exist (none ever created, or all closed) — this is an
+  # ordinary state, not an error. Fall through to a milestone-less run: skip
+  # Tier 1 entirely and proceed straight to Tier 2 (no:milestone) selection.
+  active_milestone_out="null"
+  tier1_raw='{"items": []}'
+elif [[ "$resolve_status" -ne 0 ]]; then
+  echo "$milestone_json" >&2
+  exit 1
+else
+  ms_num=$(echo "$milestone_json" | jq -r '.number')
+  ms_title=$(echo "$milestone_json" | jq -r '.title')
+  ms_due=$(echo "$milestone_json" | jq -r '.due_on')
+  active_milestone_out=$(jq -n --argjson n "$ms_num" --arg t "$ms_title" --arg d "$ms_due" \
+    '{number: $n, title: $t, due_on: $d}')
+fi
 
 # ─── 2. Fetch project items (three queries) ───────────────────────────────────
 inprogress_raw=$(gh project item-list "$proj_num" --owner "$owner" \
   --format json --limit 200 --query 'is:issue status:"In Progress" assignee:@me' 2>&1) || {
   echo "Failed to fetch in-progress items: $inprogress_raw" >&2; exit 1
 }
-tier1_raw=$(gh project item-list "$proj_num" --owner "$owner" \
-  --format json --limit 200 --query "is:issue -label:type:external-blocker status:Todo milestone:\"${ms_title}\"" 2>&1) || {
-  echo "Failed to fetch Tier 1 items: $tier1_raw" >&2; exit 1
-}
+if [[ "$resolve_status" -ne 2 ]]; then
+  tier1_raw=$(gh project item-list "$proj_num" --owner "$owner" \
+    --format json --limit 200 --query "is:issue -label:type:external-blocker status:Todo milestone:\"${ms_title}\"" 2>&1) || {
+    echo "Failed to fetch Tier 1 items: $tier1_raw" >&2; exit 1
+  }
+fi
 tier2_raw=$(gh project item-list "$proj_num" --owner "$owner" \
   --format json --limit 200 --query "is:issue -label:type:external-blocker status:Todo no:milestone" 2>&1) || {
   echo "Failed to fetch Tier 2 items: $tier2_raw" >&2; exit 1

--- a/bin/resolve-milestone
+++ b/bin/resolve-milestone
@@ -77,7 +77,7 @@ fi
 count=$(echo "$milestones" | jq 'length')
 if [[ "$count" -eq 0 ]]; then
   echo "No open milestones found." >&2
-  exit 1
+  exit 2
 fi
 
 # Sort milestones:

--- a/tests/pick-item.bats
+++ b/tests/pick-item.bats
@@ -417,6 +417,114 @@ JSON
 # sub_issues_summary included in candidate
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# #189 — resolve-milestone exit 2 (no open milestones) falls through to a
+# milestone-less run instead of exiting fatally.
+# ---------------------------------------------------------------------------
+
+@test "#189: falls back to Tier 2 with active_milestone null when resolve-milestone exits 2" {
+  cat > "$MOCK_BIN/resolve-milestone" << 'SCRIPT'
+#!/usr/bin/env bash
+echo "No open milestones found." >&2
+exit 2
+SCRIPT
+  chmod +x "$MOCK_BIN/resolve-milestone"
+
+  # Tier 1 must never be queried in this fallback — error out if it is, to
+  # prove pick-item skips that call path entirely.
+  cat > "$MOCK_BIN/gh" << 'SCRIPT'
+#!/usr/bin/env bash
+subcmd="${1:-}"
+shift || true
+
+if [[ "$subcmd" == "api" ]]; then
+  path="${1:-}"
+  if [[ "$path" =~ ^repos/[^/]+/[^/]+/issues/[0-9]+/dependencies/blocked_by$ ]]; then
+    num=$(echo "$path" | grep -oE '/issues/[0-9]+/' | grep -oE '[0-9]+')
+    file="$GH_MOCK_DIR/blockers_${num}.json"
+    if [[ -f "${file}.404" ]]; then
+      echo "HTTP 404: Not Found" >&2; exit 1
+    fi
+    cat "$file"
+  elif [[ "$path" =~ ^repos/[^/]+/[^/]+/issues/[0-9]+/sub_issues$ ]]; then
+    num=$(echo "$path" | grep -oE '/issues/[0-9]+/sub_issues' | grep -oE '[0-9]+')
+    cat "$GH_MOCK_DIR/sub_issues_${num}.json"
+  elif [[ "$path" =~ ^repos/[^/]+/[^/]+/issues/[0-9]+/parent$ ]]; then
+    num=$(echo "$path" | grep -oE '/issues/[0-9]+/parent' | grep -oE '[0-9]+')
+    file="$GH_MOCK_DIR/parent_${num}.json"
+    if [[ ! -f "$file" ]]; then
+      echo "HTTP 404: Not Found" >&2; exit 1
+    fi
+    cat "$file"
+  elif [[ "$path" =~ ^repos/[^/]+/[^/]+/issues/[0-9]+$ ]]; then
+    num=$(echo "$path" | grep -oE '/issues/[0-9]+$' | grep -oE '[0-9]+')
+    file="$GH_MOCK_DIR/issue_${num}.json"
+    if [[ -f "${file}.404" ]]; then
+      echo "HTTP 404: Not Found" >&2; exit 1
+    fi
+    cat "$file"
+  else
+    echo "Unhandled api path: $path" >&2; exit 1
+  fi
+
+elif [[ "$subcmd" == "project" ]]; then
+  subcmd2="${1:-}"
+  shift || true
+  if [[ "$subcmd2" == "item-list" ]]; then
+    args="$*"
+    if echo "$args" | grep -qF "In Progress"; then
+      cat "$GH_MOCK_DIR/items_inprogress.json"
+    elif echo "$args" | grep -qF "no:milestone"; then
+      cat "$GH_MOCK_DIR/items_tier2.json"
+    elif echo "$args" | grep -qF "milestone:"; then
+      echo "FATAL: Tier 1 (milestone-scoped) query must not run when there is no Active Release" >&2
+      exit 1
+    else
+      echo "Unhandled item-list args: $args" >&2
+      exit 1
+    fi
+  else
+    echo "Unhandled project subcmd: $subcmd2" >&2; exit 1
+  fi
+else
+  echo "Unhandled gh subcmd: $subcmd ($*)" >&2; exit 1
+fi
+SCRIPT
+  chmod +x "$MOCK_BIN/gh"
+
+  cat > "$GH_MOCK_DIR/items_tier2.json" << 'JSON'
+{"items": [{"id": "PVTI_99", "type": null, "content": {"number": 99, "title": "No-milestone item", "body": "Issue body.", "url": "https://github.com/testowner/testrepo/issues/99"}, "labels": ["type:feature", "priority:P2", "effort:S"], "milestone": null, "status": "Todo", "linked pull requests": []}]}
+JSON
+
+  no_blockers_summary 99 "No-milestone item" > "$GH_MOCK_DIR/issue_99.json"
+  echo '[]' > "$GH_MOCK_DIR/sub_issues_99.json"
+
+  run "$PICK_ITEM"
+  [[ "$status" -eq 0 ]]
+
+  active_milestone=$(echo "$output" | jq -r '.active_milestone')
+  [[ "$active_milestone" == "null" ]]
+
+  candidate_num=$(echo "$output" | jq -r '.candidate.number')
+  [[ "$candidate_num" == "99" ]]
+
+  candidate_tier=$(echo "$output" | jq -r '.candidate.tier')
+  [[ "$candidate_tier" == "2" ]]
+}
+
+@test "#189: still exits fatally for other resolve-milestone failures (missing metadata)" {
+  cat > "$MOCK_BIN/resolve-milestone" << 'SCRIPT'
+#!/usr/bin/env bash
+echo "No .claude/backlog-project.json found. Run /initialize first." >&2
+exit 1
+SCRIPT
+  chmod +x "$MOCK_BIN/resolve-milestone"
+
+  run "$PICK_ITEM"
+  [[ "$status" -ne 0 ]]
+  [[ "$status" -ne 2 ]]
+}
+
 @test "candidate includes sub_issues_summary with total and completed counts" {
   printf '{"items": [%s]}' "$(issue_item 42 'Parent with sub-issues done')" \
     > "$GH_MOCK_DIR/items_tier1.json"

--- a/tests/resolve-milestone.bats
+++ b/tests/resolve-milestone.bats
@@ -1,0 +1,155 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(dirname "$(dirname "$BATS_TEST_FILENAME")")"
+  RESOLVE_MILESTONE="$REPO_ROOT/bin/resolve-milestone"
+
+  TEST_DIR="$(mktemp -d)"
+  MOCK_BIN="$(mktemp -d)"
+  export GH_MOCK_DIR="$(mktemp -d)"
+  export PATH="$MOCK_BIN:$PATH"
+
+  cd "$TEST_DIR"
+
+  mkdir -p .claude
+  cat > .claude/backlog-project.json << 'JSON'
+{
+  "owner": "testowner",
+  "repo": "testrepo",
+  "project_number": 1
+}
+JSON
+
+  # gh mock — reads fixtures from $GH_MOCK_DIR at runtime (not expanded here)
+  cat > "$MOCK_BIN/gh" << 'SCRIPT'
+#!/usr/bin/env bash
+subcmd="${1:-}"
+shift || true
+
+if [[ "$subcmd" == "api" ]]; then
+  path="${1:-}"
+  if [[ "$path" =~ ^repos/[^/]+/[^/]+/milestones ]]; then
+    if [[ -f "$GH_MOCK_DIR/milestones_fail" ]]; then
+      echo "HTTP 401: Bad credentials" >&2
+      exit 1
+    fi
+    cat "$GH_MOCK_DIR/milestones.json"
+    exit 0
+  fi
+  echo "Unhandled api path: $path" >&2; exit 1
+else
+  echo "Unhandled gh subcmd: $subcmd ($*)" >&2; exit 1
+fi
+SCRIPT
+  chmod +x "$MOCK_BIN/gh"
+
+  # Default fixture: no milestones
+  echo '[]' > "$GH_MOCK_DIR/milestones.json"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR" "$MOCK_BIN" "$GH_MOCK_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+milestone() {
+  local number="$1" title="$2" due_on="$3"
+  if [[ -n "$due_on" ]]; then
+    printf '{"number": %s, "title": "%s", "due_on": "%s"}' "$number" "$title" "$due_on"
+  else
+    printf '{"number": %s, "title": "%s", "due_on": null}' "$number" "$title"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# No-arg: Active Release resolution
+# ---------------------------------------------------------------------------
+
+@test "no-arg: exits 0 with earliest-due-date milestone as the Active Release" {
+  printf '[%s, %s]' \
+    "$(milestone 8 'v0.6.0' '2026-07-14T00:00:00Z')" \
+    "$(milestone 11 'v0.6.2' '2026-06-01T00:00:00Z')" \
+    > "$GH_MOCK_DIR/milestones.json"
+
+  run "$RESOLVE_MILESTONE"
+  [[ "$status" -eq 0 ]]
+
+  number=$(echo "$output" | jq -r '.number')
+  title=$(echo "$output" | jq -r '.title')
+  [[ "$number" == "11" ]]
+  [[ "$title" == "v0.6.2" ]]
+}
+
+@test "no-arg: exits 2 with 'No open milestones found.' on stderr when zero open milestones" {
+  echo '[]' > "$GH_MOCK_DIR/milestones.json"
+
+  run "$RESOLVE_MILESTONE"
+  [[ "$status" -eq 2 ]]
+  [[ "$output" == *"No open milestones found."* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Named-arg resolution — two-pass match
+# ---------------------------------------------------------------------------
+
+@test "named-arg: exits 0 via substring match (pass 1)" {
+  printf '[%s, %s]' \
+    "$(milestone 8 'v0.6.0' '2026-07-14T00:00:00Z')" \
+    "$(milestone 11 'v0.6.2' '2026-06-01T00:00:00Z')" \
+    > "$GH_MOCK_DIR/milestones.json"
+
+  run "$RESOLVE_MILESTONE" "0.6.2"
+  [[ "$status" -eq 0 ]]
+
+  number=$(echo "$output" | jq -r '.number')
+  title=$(echo "$output" | jq -r '.title')
+  [[ "$number" == "11" ]]
+  [[ "$title" == "v0.6.2" ]]
+}
+
+@test "named-arg: exits 0 via stripped-v fallback match (pass 2)" {
+  # Title has no leading 'v'; only matches once both arg and title are
+  # stripped of a leading 'v' and compared for equality — substring pass
+  # would not match "v0.6.2" against "0.6.2" title without this fallback.
+  printf '[%s]' "$(milestone 11 '0.6.2' '2026-06-01T00:00:00Z')" \
+    > "$GH_MOCK_DIR/milestones.json"
+
+  run "$RESOLVE_MILESTONE" "v0.6.2"
+  [[ "$status" -eq 0 ]]
+
+  number=$(echo "$output" | jq -r '.number')
+  title=$(echo "$output" | jq -r '.title')
+  [[ "$number" == "11" ]]
+  [[ "$title" == "0.6.2" ]]
+}
+
+@test "named-arg: exits 1 when no milestone matches either pass" {
+  printf '[%s]' "$(milestone 8 'v0.6.0' '2026-07-14T00:00:00Z')" \
+    > "$GH_MOCK_DIR/milestones.json"
+
+  run "$RESOLVE_MILESTONE" "v9.9.9"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"No open milestone matching"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Infrastructure failures — exit 1, unchanged
+# ---------------------------------------------------------------------------
+
+@test "exits 1 when .claude/backlog-project.json is missing" {
+  rm .claude/backlog-project.json
+
+  run "$RESOLVE_MILESTONE"
+  [[ "$status" -eq 1 ]]
+}
+
+@test "exits 1 when the gh API call fetching milestones fails" {
+  touch "$GH_MOCK_DIR/milestones_fail"
+
+  run "$RESOLVE_MILESTONE"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"Failed to fetch milestones"* ]]
+}


### PR DESCRIPTION
## Summary

`pick-item` used to exit fatally with `No open milestones found.` whenever a repo had zero milestones at all, even though it already builds a Tier 2 (un-milestoned items) query that should serve as the fallback. This makes `resolve-milestone`'s "no open milestones" case distinguishable from other failures, and has `pick-item` fall through to a milestone-less run instead of aborting.

- `bin/resolve-milestone`: the no-arg "Active Release resolution" branch now exits `2` (instead of `1`) specifically when the open-milestone count is 0. Every other failure path (missing metadata file, `gh` API failure, named-milestone-not-found, `--exclude`-exhausted) is unchanged and still exits `1`.
- `bin/pick-item`: branches explicitly on `resolve-milestone`'s exit code — `2` sets `active_milestone` to `null` and skips the Tier 1 (milestone-scoped) query entirely, proceeding straight to Tier 2 (`no:milestone`) selection; `0` is unchanged; any other non-zero remains fatal.
- `CONTEXT.md`: amended the **Active Release** glossary entry to note it can be undefined when zero open Milestones exist, with milestone-scoped commands then operating over un-milestoned items only.

No change to the other 5 `resolve-milestone` callers (`add-item`, `plan-release`, `close-release`, `release-status`, `migrate`) — none of them branch on the specific exit code, only zero-vs-non-zero, so this change is safe for them as-is and out of scope for this fix.

Closes #189

## Acceptance Criteria mapping

- [x] `pick-item` in a repo with zero milestones (not just zero *open* ones) returns a Tier 2 candidate instead of exiting 1 — covered by `bin/pick-item`'s new exit-code branching plus `tests/pick-item.bats`'s `#189: falls back to Tier 2 with active_milestone null when resolve-milestone exits 2`.
- [x] Output JSON's `active_milestone` is `null` in this case — asserted in the same test.
- [x] `pick-item` still exits fatally for other `resolve-milestone` failures (missing metadata file, `gh` API failure) — covered by `tests/pick-item.bats`'s `#189: still exits fatally for other resolve-milestone failures (missing metadata)`, plus the unchanged `AC1b` test.
- [x] Covered by a BATS test — both `tests/pick-item.bats` (updated) and the new `tests/resolve-milestone.bats` (first direct coverage for that script, including its exit-0/1/2 paths).