### PR TITLE
fix(create-item): resolve owner/repo defaults for same-repo dependency refs

### DIFF
--- a/bin/create-item
+++ b/bin/create-item
@@ -22,8 +22,8 @@ Manifest schema (title and body_file are required; all others are optional):
   labels          array of label strings
   rank            {"position": "top"|"bottom"} | {"after_issue": N}
   rank_adjustments array of {"issue": N, "position": "top"} | {"issue": N, "after_issue": M}
-  blocked_by      array of {"owner": "...", "repo": "...", "number": N}
-  blocking        array of {"owner": "...", "repo": "...", "number": N}
+  blocked_by      array of {"number": N} | {"owner": "...", "repo": "...", "number": N}
+  blocking        array of {"number": N} | {"owner": "...", "repo": "...", "number": N}
   parent          integer (issue number)
   milestone       string (milestone title)
 EOF
@@ -82,31 +82,90 @@ blocking_json=$(echo "$manifest" | jq -c '.blocking // []')
 parent_num=$(echo "$manifest" | jq -r '.parent // null')
 milestone_title=$(echo "$manifest" | jq -r '.milestone // null')
 
-n_blocked_by=$(echo "$blocked_by_json" | jq 'length')
-n_blocking=$(echo "$blocking_json" | jq 'length')
-
 [[ -z "$title" || "$title" == "null" ]] && { echo "Manifest missing required field: title" >&2; exit 1; }
 [[ -z "$body_file" || "$body_file" == "null" ]] && { echo "Manifest missing required field: body_file" >&2; exit 1; }
 [[ ! -f "$body_file" ]] && { echo "body_file not found: $body_file" >&2; exit 1; }
+
+# ─── Validate + normalize dependency references ───────────────────────────
+# blocked_by/blocking entries may omit owner/repo, in which case they mean
+# "this Project's repo". Resolve that default here and reject malformed
+# entries before any mutation — an entry missing owner/repo must never reach
+# the URL branch below, which would interpolate literal nulls into the ref.
+deps=$(jq -n \
+  --argjson blocked_by "$blocked_by_json" \
+  --argjson blocking   "$blocking_json" \
+  --arg     owner      "$owner" \
+  --arg     repo       "$repo" '
+  def present($k): has($k) and (.[$k] != null);
+
+  def entry_errors($p): [
+    (if present("number") | not then
+       $p + "missing required field: number"
+     elif (.number | type) != "number" then
+       $p + "number must be an integer >= 1, got " + (.number | tojson)
+     elif (.number | floor) != .number or .number < 1 then
+       $p + "number must be an integer >= 1, got " + (.number | tojson)
+     else empty end),
+    (if present("owner") != present("repo") then
+       $p + "owner and repo must both be present or both be omitted"
+     else empty end),
+    (if present("owner") and ((.owner | type) != "string" or .owner == "") then
+       $p + "owner must be a non-empty string"
+     else empty end),
+    (if present("repo") and ((.repo | type) != "string" or .repo == "") then
+       $p + "repo must be a non-empty string"
+     else empty end)
+  ];
+
+  def resolve($field): . as $arr
+    | if ($arr | type) != "array" then
+        {errors: [$field + " must be an array, got " + ($arr | type)], refs: []}
+      else
+        [ $arr | to_entries[]
+          | ($field + "[" + (.key | tostring) + "]: ") as $p
+          | .value
+          | if type != "object" then
+              {errors: [$p + "entry must be an object with a number field, got " + tojson], ref: null}
+            else
+              entry_errors($p) as $errs
+              | if ($errs | length) > 0 then {errors: $errs, ref: null}
+                else
+                  (if present("owner") then .owner else $owner end) as $o
+                  | (if present("repo") then .repo else $repo end) as $r
+                  | {errors: [],
+                     ref: (if $o == $owner and $r == $repo
+                           then (.number | tostring)
+                           else "https://github.com/\($o)/\($r)/issues/\(.number)" end)}
+                end
+            end
+        ] as $rows
+        | {errors: [$rows[].errors[]],
+           refs:   [$rows[] | select(.ref != null) | .ref]}
+      end;
+
+  ($blocked_by | resolve("blocked_by")) as $bb
+  | ($blocking | resolve("blocking")) as $bl
+  | {errors:          ($bb.errors + $bl.errors),
+     blocked_by_refs: ($bb.refs | join(",")),
+     blocking_refs:   ($bl.refs | join(","))}
+')
+
+dep_errors=$(echo "$deps" | jq -r '.errors[]')
+if [[ -n "$dep_errors" ]]; then
+  echo "$dep_errors" >&2
+  exit 1
+fi
+
+blocked_by_refs=$(echo "$deps" | jq -r '.blocked_by_refs')
+blocking_refs=$(echo "$deps" | jq -r '.blocking_refs')
 
 # ─── 1. Create the issue ───────────────────────────────────────────────────
 labels_csv=$(echo "$labels_json" | jq -r 'join(",")')
 create_args=(--title "$title" --body-file "$body_file" --project "$proj_title")
 [[ -n "$labels_csv" ]] && create_args+=(--label "$labels_csv")
 
-if [[ "$n_blocked_by" -gt 0 ]]; then
-  blocked_by_refs=$(echo "$blocked_by_json" | jq -r \
-    --arg owner "$owner" --arg repo "$repo" \
-    '[.[] | if .owner == $owner and .repo == $repo then (.number | tostring) else "https://github.com/\(.owner)/\(.repo)/issues/\(.number)" end] | join(",")')
-  create_args+=(--blocked-by "$blocked_by_refs")
-fi
-
-if [[ "$n_blocking" -gt 0 ]]; then
-  blocking_refs=$(echo "$blocking_json" | jq -r \
-    --arg owner "$owner" --arg repo "$repo" \
-    '[.[] | if .owner == $owner and .repo == $repo then (.number | tostring) else "https://github.com/\(.owner)/\(.repo)/issues/\(.number)" end] | join(",")')
-  create_args+=(--blocking "$blocking_refs")
-fi
+[[ -n "$blocked_by_refs" ]] && create_args+=(--blocked-by "$blocked_by_refs")
+[[ -n "$blocking_refs" ]]   && create_args+=(--blocking "$blocking_refs")
 
 [[ "$parent_num" != "null" ]] && create_args+=(--parent "$parent_num")
 [[ "$milestone_title" != "null" ]] && create_args+=(--milestone "$milestone_title")

--- a/skills/add-item/SKILL.md
+++ b/skills/add-item/SKILL.md
@@ -183,5 +183,4 @@ Using the JSON blob returned by `create-item`, print:
 - Issue body section headings MUST match the Issue Forms template exactly (case + ordering) so `audit` can parse them
 - Never apply more than one label per group (one type, one priority, one effort)
 - Dependencies and sub-issue parent are NOT mirrored in the issue body — GitHub's native API is the only source of truth for these relationships
-- Cross-Project / cross-repo blockers ARE permitted but will be flagged as a smell by `audit`
 - Sub-issues stay independent — assigning a parent does NOT inherit the parent's milestone, priority, effort, type, or Project rank

--- a/skills/add-item/issue-manifest.md
+++ b/skills/add-item/issue-manifest.md
@@ -11,8 +11,8 @@ The manifest is a JSON file passed to `create-item --input <file>`.
   "labels": ["type:<x>", "priority:<y>", "effort:<z>"],
   "rank": {"position": "top"} | {"position": "bottom"} | {"after_issue": N},
   "rank_adjustments": [{"issue": N, "position": "top"} | {"issue": N, "after_issue": M}],
-  "blocked_by": [{"owner": "...", "repo": "...", "number": N}],
-  "blocking":   [{"owner": "...", "repo": "...", "number": N}],
+  "blocked_by": [{"number": N} | {"owner": "...", "repo": "...", "number": N}],
+  "blocking":   [{"number": N} | {"owner": "...", "repo": "...", "number": N}],
   "parent": <integer issue number>,
   "milestone": "<milestone title>"
 }
@@ -21,4 +21,3 @@ The manifest is a JSON file passed to `create-item --input <file>`.
 ## Field Notes
 
 - `rank` / `rank_adjustments` — use `after_issue: N` with the issue number of the item to position after
-- `blocked_by` / `blocking` — cross-repo references are allowed; include `owner` and `repo` for cross-repo items; same-repo items need only `number`

--- a/tests/create-item.bats
+++ b/tests/create-item.bats
@@ -58,6 +58,7 @@ if [[ "$subcmd" == "issue" ]]; then
   subcmd2="${1:-}"; shift || true
   if [[ "$subcmd2" == "create" ]]; then
     [[ -f "$GH_MOCK_DIR/issue_create_fail" ]] && { echo "gh issue create: simulated failure" >&2; exit 1; }
+    printf '%s\n' "$@" > "$GH_MOCK_DIR/issue_create_args"
     # Flag-specific failures
     while [[ $# -gt 0 ]]; do
       case "$1" in
@@ -392,4 +393,163 @@ JSON
 
   run "$CREATE_ITEM" --input "$manifest"
   [[ "$status" -ne 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Dependency reference resolution (#199)
+# ---------------------------------------------------------------------------
+
+# Helper: emit a manifest whose blocked_by/blocking are taken verbatim.
+write_dep_manifest() {
+  local blocked_by="$1" blocking="${2:-[]}"
+  cat > "$GH_MOCK_DIR/manifest.json" << JSON
+{
+  "title": "Dependency issue",
+  "body_file": "$GH_MOCK_DIR/body.txt",
+  "labels": ["type:bug", "priority:P1", "effort:S"],
+  "blocked_by": $blocked_by,
+  "blocking": $blocking
+}
+JSON
+  echo "$GH_MOCK_DIR/manifest.json"
+}
+
+# Helper: value passed to a given flag of `gh issue create`.
+flag_value() {
+  grep -A1 -x -- "$1" "$GH_MOCK_DIR/issue_create_args" | tail -1
+}
+
+@test "deps: same-repo short form {number} resolves to a bare number" {
+  local manifest; manifest="$(write_dep_manifest '[{"number": 68}]')"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 0 ]]
+  [[ "$(flag_value --blocked-by)" == "68" ]]
+}
+
+@test "deps: explicit local triple resolves identically to the short form" {
+  local manifest; manifest="$(write_dep_manifest \
+    '[{"owner": "testowner", "repo": "testrepo", "number": 68}]')"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 0 ]]
+  [[ "$(flag_value --blocked-by)" == "68" ]]
+}
+
+@test "deps: cross-repo triple still resolves to a full URL" {
+  local manifest; manifest="$(write_dep_manifest \
+    '[{"owner": "otherorg", "repo": "otherrepo", "number": 68}]')"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 0 ]]
+  [[ "$(flag_value --blocked-by)" == "https://github.com/otherorg/otherrepo/issues/68" ]]
+}
+
+@test "deps: mixed local and cross-repo entries join in manifest order" {
+  local manifest; manifest="$(write_dep_manifest \
+    '[{"number": 12}, {"owner": "otherorg", "repo": "otherrepo", "number": 68}]')"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 0 ]]
+  [[ "$(flag_value --blocked-by)" == "12,https://github.com/otherorg/otherrepo/issues/68" ]]
+}
+
+@test "deps: short form applies to blocking as well as blocked_by" {
+  local manifest; manifest="$(write_dep_manifest '[]' '[{"number": 77}]')"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 0 ]]
+  [[ "$(flag_value --blocking)" == "77" ]]
+}
+
+@test "deps: no null/null URL is ever constructed" {
+  local manifest; manifest="$(write_dep_manifest '[{"number": 68}]')"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$output" != *"null/null"* ]]
+  ! grep -q "null/null" "$GH_MOCK_DIR/issue_create_args"
+}
+
+@test "deps: repo without owner is rejected before gh runs" {
+  local manifest; manifest="$(write_dep_manifest '[{"repo": "other", "number": 68}]')"
+  rm -f "$GH_MOCK_DIR/issue_create_args"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"blocked_by[0]"* ]]
+  [[ "$output" == *"owner and repo must both be present or both be omitted"* ]]
+  [[ ! -f "$GH_MOCK_DIR/issue_create_args" ]]
+}
+
+@test "deps: owner without repo is rejected" {
+  local manifest; manifest="$(write_dep_manifest '[{"owner": "otherorg", "number": 68}]')"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"owner and repo must both be present or both be omitted"* ]]
+}
+
+@test "deps: bare integer entry is rejected with the received value" {
+  local manifest; manifest="$(write_dep_manifest '[68]')"
+  rm -f "$GH_MOCK_DIR/issue_create_args"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"blocked_by[0]"* ]]
+  [[ "$output" == *"entry must be an object with a number field, got 68"* ]]
+  [[ ! -f "$GH_MOCK_DIR/issue_create_args" ]]
+}
+
+@test "deps: quoted number is rejected" {
+  local manifest; manifest="$(write_dep_manifest '[{"number": "68"}]')"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *'number must be an integer >= 1, got "68"'* ]]
+}
+
+@test "deps: zero and negative numbers are rejected" {
+  local manifest; manifest="$(write_dep_manifest '[{"number": 0}, {"number": -3}]')"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"blocked_by[0]: number must be an integer >= 1, got 0"* ]]
+  [[ "$output" == *"blocked_by[1]: number must be an integer >= 1, got -3"* ]]
+}
+
+@test "deps: missing number is rejected" {
+  local manifest; manifest="$(write_dep_manifest \
+    '[{"owner": "otherorg", "repo": "otherrepo"}]')"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"blocked_by[0]: missing required field: number"* ]]
+}
+
+@test "deps: errors accumulate across blocked_by and blocking in one run" {
+  local manifest; manifest="$(write_dep_manifest \
+    '[{"repo": "other", "number": 1}, 68]' \
+    '[{"number": 0}]')"
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"blocked_by[0]: owner and repo must both be present"* ]]
+  [[ "$output" == *"blocked_by[1]: entry must be an object"* ]]
+  [[ "$output" == *"blocking[0]: number must be an integer >= 1"* ]]
+}
+
+@test "deps: omitted dependency fields pass no flags to gh issue create" {
+  local manifest="$GH_MOCK_DIR/manifest.json"
+  cat > "$manifest" << JSON
+{
+  "title": "No deps",
+  "body_file": "$GH_MOCK_DIR/body.txt",
+  "labels": ["type:bug", "priority:P1", "effort:S"]
+}
+JSON
+
+  run "$CREATE_ITEM" --input "$manifest"
+  [[ "$status" -eq 0 ]]
+  ! grep -q -x -- "--blocked-by" "$GH_MOCK_DIR/issue_create_args"
+  ! grep -q -x -- "--blocking" "$GH_MOCK_DIR/issue_create_args"
 }


### PR DESCRIPTION
## Problem

`issue-manifest.md` documents `{"number": N}` as a valid `blocked_by` / `blocking` entry for the Project's own repo. `bin/create-item` never implemented that default.

The ref builder branched on `.owner == $owner and .repo == $repo`. With both keys absent jq yields `null`, the equality fails, and control falls through to the cross-repo branch — interpolating the nulls into a URL:

```
"https://github.com/null/null/issues/68": GraphQL: Could not resolve to a
Repository with the name 'null/null'. (repository)
```

`--blocked-by` rides the same `gh issue create` call that creates the issue, so this was fatal: exit 1, nothing created. Both `add-item` and `migrate` sit on this path.

## Change

The two duplicated jq ref builders become one validating normalizer, running before any mutation. Entries must be objects with an integer `number >= 1`; `owner` and `repo` must both be present or both absent, defaulting to the Project's repo when omitted. Errors across both arrays accumulate and report together, then exit 1.

Resolved-ref rendering is untouched — local refs stay bare numbers, cross-repo refs stay full URLs. The `null` interpolation is now unreachable.

A lone `owner` or `repo` is rejected rather than partially resolved: `{"repo": "other", "number": 68}` almost certainly means another org with a forgotten `owner`, and defaulting each key independently would create a real-but-wrong edge and exit 0.

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gq8UeD4P5XC3qHdixt7z6V